### PR TITLE
Code style improvements + optional CI job (clippy, rustfmt, rustdoc)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,3 +20,18 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+
+
+  # As discussed, these tasks are optional for PRs.
+  style_checks:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Rustfmt
+      run: cargo fmt -- --check
+    - name: Clippy
+      run: cargo clippy
+    - name: Rustdoc
+      run: cargo doc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: rust
-rust:
-  - stable
-  - beta
-  - nightly
-matrix:
-  allow_failures:
-    - rust: stable

--- a/src/header.rs
+++ b/src/header.rs
@@ -11,11 +11,10 @@ use core::marker::PhantomData;
 pub const MULTIBOOT2_BOOTLOADER_MAGIC: u32 = 0x36d76289;
 
 /// Possible types of a Tag in the Multiboot2 Information Structure (MBI), therefore the value
-/// of the the `typ` field in [`Tag`]. The names and values are taken from the example C code
+/// of the the `typ` property. The names and values are taken from the example C code
 /// at the bottom of the Multiboot2 specification.
 #[repr(u32)]
 #[derive(Copy, Clone, Debug)]
-#[allow(missing_docs)]
 pub enum TagType {
     /// Marks the end of the tags.
     End = 0,

--- a/src/memory_map.rs
+++ b/src/memory_map.rs
@@ -1,5 +1,5 @@
-use core::marker::PhantomData;
 use crate::TagType;
+use core::marker::PhantomData;
 
 /// This Tag provides an initial host memory map.
 ///
@@ -24,7 +24,8 @@ pub struct MemoryMapTag {
 impl MemoryMapTag {
     /// Return an iterator over all AVAILABLE marked memory areas.
     pub fn memory_areas(&self) -> impl Iterator<Item = &MemoryArea> {
-        self.all_memory_areas().filter(|entry| matches!(entry.typ, MemoryAreaType::Available))
+        self.all_memory_areas()
+            .filter(|entry| matches!(entry.typ, MemoryAreaType::Available))
     }
 
     /// Return an iterator over all marked memory areas.

--- a/src/module.rs
+++ b/src/module.rs
@@ -24,7 +24,10 @@ impl ModuleTag {
         use core::{mem, slice, str};
         let strlen = self.size as usize - mem::size_of::<ModuleTag>();
         unsafe {
-            str::from_utf8_unchecked(slice::from_raw_parts(&self.cmdline_str as *const u8, strlen))
+            str::from_utf8_unchecked(slice::from_raw_parts(
+                &self.cmdline_str as *const u8,
+                strlen,
+            ))
         }
     }
 
@@ -47,9 +50,9 @@ impl ModuleTag {
 impl Debug for ModuleTag {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("ModuleTag")
-            .field("type", &self.typ)
-            .field("size (tag)", &self.size)
-            .field("size (module)", &(self.module_size()))
+            .field("type", &{ self.typ })
+            .field("size (tag)", &{ self.size })
+            .field("size (module)", &self.module_size())
             .field("mod_start", &(self.mod_start as *const usize))
             .field("mod_end", &(self.mod_end as *const usize))
             .field("cmdline", &self.cmdline())

--- a/src/rsdp.rs
+++ b/src/rsdp.rs
@@ -8,9 +8,9 @@
 //!
 //! Even though the bootloader should give the address of the real RSDP/XSDT, the checksum and
 //! signature should be manually verified.
+use crate::TagType;
 use core::slice;
 use core::str;
-use crate::TagType;
 
 const RSDPV1_LENGTH: usize = 20;
 

--- a/src/vbe_info.rs
+++ b/src/vbe_info.rs
@@ -1,5 +1,5 @@
-use core::fmt;
 use crate::TagType;
+use core::fmt;
 
 /// This tag contains VBE metadata, VBE controller information returned by the
 /// VBE Function 00h and VBE mode information returned by the VBE Function 01h.


### PR DESCRIPTION
- add clippy check as required
- add rustfmt check as required
- add rustdoc check as required (`#![deny(rustdoc::all)]` works since stable 1.52.0)

To improve and enforce code quality.

I'm not sure if we still use Travis CI. 

What's your opinion on this @Caduser2020  @IsaacWoods ?