### PR TITLE
Editorconfig file.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,8 @@
 # TODO 0.12.2 / 0.13
 - internal improvements
-  - code formatting/style 
+  - code formatting/style
   - sensible style checks as optional CI job
+  - `.editorconfig` file
 
 # 0.12.1
 - `TagType`-enum introduced in `v0.11` is now actually public


### PR DESCRIPTION
This change doesn't change the formatting of existing code, but makes sure all IDEs with support for this (VIM, Jetbrains IDEs, VS Code) use the same spacing style that `rustfmt` also uses by default. This makes a `cargo fmt` needless in most cases.