### PR TITLE
multiboot2 v0.12.2 (std in tests; hash for TagType)

### DIFF
--- a/multiboot2/Cargo.toml
+++ b/multiboot2/Cargo.toml
@@ -6,7 +6,7 @@ Multiboot2-compliant bootloaders, like GRUB. It supports all tags from the speci
 including full support for the sections of ELF-64. This library is `no_std` and can be
 used in a Multiboot2-kernel.
 """
-version = "0.12.1"
+version = "0.12.2"
 authors = [
     "Philipp Oppermann <dev@phil-opp.com>",
     "Calvin Lee <cyrus296@gmail.com>",

--- a/multiboot2/Changelog.md
+++ b/multiboot2/Changelog.md
@@ -1,7 +1,11 @@
 # CHANGELOG for crate `multiboot2`
 
-## TODO 0.12.2 / 0.13
+## 0.12.2
+- `TagType` now implements `Eq` and `Hash`
 - internal improvements
+  - `std` can be used in tests; the crate is still `no_std`
+    - this implies that `cargo test` doesn't work on "non-standard" targets
+    - CI (Ubuntu) still works.
   - code formatting/style
   - sensible style checks as optional CI job
   - `.editorconfig` file

--- a/multiboot2/src/lib.rs
+++ b/multiboot2/src/lib.rs
@@ -1,4 +1,5 @@
-#![no_std]
+// this crate can use `std` in tests only
+#![cfg_attr(not(test), no_std)]
 #![deny(missing_debug_implementations)]
 // --- BEGIN STYLE CHECKS ---
 // These checks are optional in CI for PRs, as discussed in
@@ -29,6 +30,11 @@
 //!     println!("{:?}", boot_info);
 //! }
 //! ```
+
+// this crate can use std in tests only
+#[cfg_attr(test, macro_use)]
+#[cfg(test)]
+extern crate std;
 
 use core::fmt;
 


### PR DESCRIPTION
This crate now supports `std` in tests but is still `no_std` itself. `TagType` implements now `Hash` so that it can be used in `HashSet`. This is a requirement for the upcoming release of `multiboot2-header`.