### PR TITLE
repo: add CI no_std check

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,6 @@ insert_final_newline = true
 indent_style = space
 indent_size = 4
 trim_trailing_whitespace = true
+
+[*.yml]
+indent_size = 2

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,6 @@ env:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     strategy:
         matrix:
@@ -25,6 +24,21 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+
+  build_no_std:
+      runs-on: ubuntu-latest
+      strategy:
+          matrix:
+              rust:
+                  - stable
+                  - nightly
+                  - 1.52.1 # MSVR
+      steps:
+          -   uses: actions/checkout@v2
+          -   name: "Rustup: install some no_std target"
+              run: rustup target add thumbv7em-none-eabihf
+          -   name: Build (no_std)
+              run: cargo build --target thumbv7em-none-eabihf
 
 
   # As discussed, these tasks are optional for PRs.

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,48 +13,46 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
-        matrix:
-            rust:
-                - stable
-                - nightly
-                - 1.52.1 # MSVR
+      matrix:
+        rust:
+          - stable
+          - nightly
+          - 1.52.1 # MSVR
     steps:
-    - uses: actions/checkout@v2
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
+      - uses: actions/checkout@v2
+      - name: Build
+        run: cargo build --verbose
+      - name: Run tests
+        run: cargo test --verbose
 
   build_no_std:
-      runs-on: ubuntu-latest
-      strategy:
-          matrix:
-              rust:
-                  - stable
-                  - nightly
-                  - 1.52.1 # MSVR
-      steps:
-          -   uses: actions/checkout@v2
-          -   name: "Rustup: install some no_std target"
-              run: rustup target add thumbv7em-none-eabihf
-          -   name: Build (no_std)
-              run: cargo build --target thumbv7em-none-eabihf
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - nightly
+          - 1.52.1 # MSVR
+    steps:
+      - uses: actions/checkout@v2
+      - name: "Rustup: install some no_std target"
+        run: rustup target add thumbv7em-none-eabihf
+      - name: Build (no_std)
+        run: cargo build --target thumbv7em-none-eabihf
 
 
   # As discussed, these tasks are optional for PRs.
   style_checks:
-
     runs-on: ubuntu-latest
     strategy:
-        matrix:
-            rust:
-                - stable
-
+      matrix:
+        rust:
+          - stable
     steps:
-    - uses: actions/checkout@v2
-    - name: Rustfmt
-      run: cargo fmt -- --check
-    - name: Clippy
-      run: cargo clippy
-    - name: Rustdoc
-      run: cargo doc
+      - uses: actions/checkout@v2
+      - name: Rustfmt
+        run: cargo fmt -- --check
+      - name: Clippy
+        run: cargo clippy
+      - name: Rustdoc
+        run: cargo doc


### PR DESCRIPTION
Currently, the CI does not check if this actually builds with `no_std`. This MR fixes this.

After #98 is fixed, this should be mandatory for all new MRs