### PR TITLE
multiboot2-header: fix `no_std`-build + v0.1.1

### DIFF
--- a/multiboot2-header/Cargo.toml
+++ b/multiboot2-header/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 Library with type definitions and parsing functions for Multiboot2 headers.
 This library is `no_std` and can be used in bootloaders.
 """
-version = "0.1.0"
+version = "0.1.1"
 authors = [
     "Philipp Schuster <phip1611@gmail.com>"
 ]
@@ -27,6 +27,12 @@ homepage = "https://github.com/rust-osdev/multiboot2-header"
 repository = "https://github.com/rust-osdev/multiboot2"
 documentation = "https://docs.rs/multiboot2-header"
 
+[features]
+# by default, builder is included
+default = ["builder"]
+std = []
+builder = ["std"]
+
 [dependencies]
 # used for MBI tags
-multiboot2 = "0.12.2"
+multiboot2 = "0.13.2"

--- a/multiboot2-header/README.md
+++ b/multiboot2-header/README.md
@@ -15,6 +15,18 @@ What this library is good for:
 What this library is not optimal for:
 - compiling a Multiboot2 header statically into an object file using only Rust code
 
+## Features and Usage in `no_std`
+This library is always `no_std`. However, the `builder`-feature requires the `alloc`-crate
+to be available. You need the `builder` only if you want to construct new headers. For parsing,
+this is not relevant.
+
+```toml
+# without `builder`-feature (and without `alloc`-crate)
+multiboot2-header = { version = "<latest>", default-features = false }
+# else (requires `alloc`-crate)
+multiboot2-header = "<latest>"
+```
+
 ## Example 1: Builder + Parse
 ```rust
 use multiboot2_header::builder::Multiboot2HeaderBuilder;

--- a/multiboot2-header/src/address.rs
+++ b/multiboot2-header/src/address.rs
@@ -1,4 +1,4 @@
-use crate::{HeaderTagFlag, HeaderTagType, StructAsBytes};
+use crate::{HeaderTagFlag, HeaderTagType};
 use core::mem::size_of;
 
 /// This information does not need to be provided if the kernel image is in ELF
@@ -65,4 +65,5 @@ impl AddressHeaderTag {
     }
 }
 
-impl StructAsBytes for AddressHeaderTag {}
+#[cfg(feature = "builder")]
+impl crate::StructAsBytes for AddressHeaderTag {}

--- a/multiboot2-header/src/console.rs
+++ b/multiboot2-header/src/console.rs
@@ -1,4 +1,4 @@
-use crate::{HeaderTagFlag, HeaderTagType, StructAsBytes};
+use crate::{HeaderTagFlag, HeaderTagType};
 use core::mem::size_of;
 
 /// Possible flags for [`ConsoleHeaderTag`].
@@ -46,7 +46,8 @@ impl ConsoleHeaderTag {
     }
 }
 
-impl StructAsBytes for ConsoleHeaderTag {}
+#[cfg(feature = "builder")]
+impl crate::StructAsBytes for ConsoleHeaderTag {}
 
 #[cfg(test)]
 mod tests {

--- a/multiboot2-header/src/end.rs
+++ b/multiboot2-header/src/end.rs
@@ -1,4 +1,4 @@
-use crate::{HeaderTagFlag, HeaderTagType, StructAsBytes};
+use crate::{HeaderTagFlag, HeaderTagType};
 use core::mem::size_of;
 
 /// Terminates a list of optional tags
@@ -33,4 +33,5 @@ impl EndHeaderTag {
     }
 }
 
-impl StructAsBytes for EndHeaderTag {}
+#[cfg(feature = "builder")]
+impl crate::StructAsBytes for EndHeaderTag {}

--- a/multiboot2-header/src/entry_efi_32.rs
+++ b/multiboot2-header/src/entry_efi_32.rs
@@ -1,4 +1,4 @@
-use crate::{HeaderTagFlag, HeaderTagType, StructAsBytes};
+use crate::{HeaderTagFlag, HeaderTagType};
 use core::fmt;
 use core::fmt::{Debug, Formatter};
 use core::mem::size_of;
@@ -50,4 +50,5 @@ impl Debug for EntryEfi32HeaderTag {
     }
 }
 
-impl StructAsBytes for EntryEfi32HeaderTag {}
+#[cfg(feature = "builder")]
+impl crate::StructAsBytes for EntryEfi32HeaderTag {}

--- a/multiboot2-header/src/entry_efi_64.rs
+++ b/multiboot2-header/src/entry_efi_64.rs
@@ -1,4 +1,4 @@
-use crate::{HeaderTagFlag, HeaderTagType, StructAsBytes};
+use crate::{HeaderTagFlag, HeaderTagType};
 use core::fmt;
 use core::fmt::{Debug, Formatter};
 use core::mem::size_of;
@@ -50,4 +50,5 @@ impl Debug for EntryEfi64HeaderTag {
     }
 }
 
-impl StructAsBytes for EntryEfi64HeaderTag {}
+#[cfg(feature = "builder")]
+impl crate::StructAsBytes for EntryEfi64HeaderTag {}

--- a/multiboot2-header/src/entry_header.rs
+++ b/multiboot2-header/src/entry_header.rs
@@ -1,4 +1,4 @@
-use crate::{HeaderTagFlag, HeaderTagType, StructAsBytes};
+use crate::{HeaderTagFlag, HeaderTagType};
 use core::fmt;
 use core::fmt::{Debug, Formatter};
 use core::mem::size_of;
@@ -50,4 +50,5 @@ impl Debug for EntryHeaderTag {
     }
 }
 
-impl StructAsBytes for EntryHeaderTag {}
+#[cfg(feature = "builder")]
+impl crate::StructAsBytes for EntryHeaderTag {}

--- a/multiboot2-header/src/framebuffer.rs
+++ b/multiboot2-header/src/framebuffer.rs
@@ -1,4 +1,4 @@
-use crate::{HeaderTagFlag, HeaderTagType, StructAsBytes};
+use crate::{HeaderTagFlag, HeaderTagType};
 use core::mem::size_of;
 
 /// Specifies the preferred graphics mode. If this tag
@@ -48,4 +48,5 @@ impl FramebufferHeaderTag {
     }
 }
 
-impl StructAsBytes for FramebufferHeaderTag {}
+#[cfg(feature = "builder")]
+impl crate::StructAsBytes for FramebufferHeaderTag {}

--- a/multiboot2-header/src/header/builder.rs
+++ b/multiboot2-header/src/header/builder.rs
@@ -6,6 +6,7 @@ use crate::{
     EntryEfi64HeaderTag, EntryHeaderTag, FramebufferHeaderTag, InformationRequestHeaderTagBuilder,
     ModuleAlignHeaderTag, Multiboot2BasicHeader, RelocatableHeaderTag, StructAsBytes,
 };
+use alloc::vec::Vec;
 use core::mem::size_of;
 
 /// Builder to construct a valid Multiboot2 header dynamically at runtime.

--- a/multiboot2-header/src/header/mod.rs
+++ b/multiboot2-header/src/header/mod.rs
@@ -4,7 +4,7 @@
 pub mod builder;
 
 pub use self::builder::*;
-use crate::{AddressHeaderTag, InformationRequestHeaderTag, RelocatableHeaderTag, StructAsBytes};
+use crate::{AddressHeaderTag, InformationRequestHeaderTag, RelocatableHeaderTag};
 use crate::{ConsoleHeaderTag, EntryHeaderTag};
 use crate::{EfiBootServiceHeaderTag, FramebufferHeaderTag};
 use crate::{EndHeaderTag, HeaderTagType};
@@ -194,7 +194,8 @@ impl Debug for Multiboot2BasicHeader {
     }
 }
 
-impl StructAsBytes for Multiboot2BasicHeader {}
+#[cfg(feature = "builder")]
+impl crate::StructAsBytes for Multiboot2BasicHeader {}
 
 /// Iterator over all tags of a Multiboot2 header. The number of items is derived
 /// by the size/length of the header.

--- a/multiboot2-header/src/information_request.rs
+++ b/multiboot2-header/src/information_request.rs
@@ -1,10 +1,15 @@
+use crate::HeaderTagType;
+#[cfg(feature = "builder")]
+use crate::StructAsBytes;
 use crate::{HeaderTagFlag, MbiTagType};
-use crate::{HeaderTagType, StructAsBytes};
+#[cfg(feature = "builder")]
+use alloc::collections::BTreeSet;
+#[cfg(feature = "builder")]
+use alloc::vec::Vec;
 use core::fmt;
 use core::fmt::{Debug, Formatter};
 use core::marker::PhantomData;
 use core::mem::size_of;
-use std::collections::HashSet;
 
 /// Specifies what specific tag types the bootloader should provide
 /// inside the mbi.
@@ -87,21 +92,24 @@ impl<const N: usize> Debug for InformationRequestHeaderTag<N> {
     }
 }
 
-impl<const N: usize> StructAsBytes for InformationRequestHeaderTag<N> {}
+#[cfg(feature = "builder")]
+impl<const N: usize> crate::StructAsBytes for InformationRequestHeaderTag<N> {}
 
 /// Helper to build the dynamically sized [`InformationRequestHeaderTag`]
 /// at runtime.
 #[derive(Debug)]
+#[cfg(feature = "builder")]
 pub struct InformationRequestHeaderTagBuilder {
     flag: HeaderTagFlag,
-    irs: HashSet<MbiTagType>,
+    irs: BTreeSet<MbiTagType>,
 }
 
+#[cfg(feature = "builder")]
 impl InformationRequestHeaderTagBuilder {
     /// New builder.
     pub fn new(flag: HeaderTagFlag) -> Self {
         Self {
-            irs: HashSet::new(),
+            irs: BTreeSet::new(),
             flag,
         }
     }

--- a/multiboot2-header/src/lib.rs
+++ b/multiboot2-header/src/lib.rs
@@ -30,11 +30,19 @@
 //!
 //! ```
 
+#![no_std]
 #![deny(rustdoc::all)]
 #![allow(rustdoc::missing_doc_code_examples)]
 #![deny(clippy::all)]
 #![deny(clippy::missing_const_for_fn)]
 #![deny(missing_debug_implementations)]
+
+#[cfg(feature = "builder")]
+extern crate alloc;
+
+#[cfg_attr(test, macro_use)]
+#[cfg(test)]
+extern crate std;
 
 #[cfg_attr(test, macro_use)]
 #[cfg(test)]
@@ -68,14 +76,15 @@ pub use self::relocatable::*;
 pub use self::tags::*;
 pub use self::uefi_bs::*;
 
+use core::mem::size_of;
 /// Re-export of [`multiboot2::TagType`] from `multiboot2`-crate as `MbiTagType`, i.e. tags that
 /// describe the entries in the Multiboot2 Information Structure (MBI).
 pub use multiboot2::TagType as MbiTagType;
-use std::mem::size_of;
 
 /// Trait for all tags that creates a byte array from the tag.
 /// Useful in builders to construct a byte vector that
 /// represents the Multiboot2 header with all its tags.
+#[cfg(feature = "builder")]
 pub(crate) trait StructAsBytes: Sized {
     /// Returns the size in bytes of the struct, as known during compile
     /// time. This doesn't use read the "size" field of tags.
@@ -90,9 +99,9 @@ pub(crate) trait StructAsBytes: Sized {
 
     /// Returns the structure as a vector of its bytes.
     /// The length is determined by [`size`].
-    fn struct_as_bytes(&self) -> Vec<u8> {
+    fn struct_as_bytes(&self) -> alloc::vec::Vec<u8> {
         let ptr = self.as_ptr();
-        let mut vec = Vec::with_capacity(self.byte_size());
+        let mut vec = alloc::vec::Vec::with_capacity(self.byte_size());
         for i in 0..self.byte_size() {
             vec.push(unsafe { *ptr.add(i) })
         }

--- a/multiboot2-header/src/module_alignment.rs
+++ b/multiboot2-header/src/module_alignment.rs
@@ -1,4 +1,4 @@
-use crate::{HeaderTagFlag, HeaderTagType, StructAsBytes};
+use crate::{HeaderTagFlag, HeaderTagType};
 use core::mem::size_of;
 
 /// If this tag is present, provided boot modules must be page aligned.
@@ -30,4 +30,5 @@ impl ModuleAlignHeaderTag {
     }
 }
 
-impl StructAsBytes for ModuleAlignHeaderTag {}
+#[cfg(feature = "builder")]
+impl crate::StructAsBytes for ModuleAlignHeaderTag {}

--- a/multiboot2-header/src/relocatable.rs
+++ b/multiboot2-header/src/relocatable.rs
@@ -1,4 +1,4 @@
-use crate::{HeaderTagFlag, HeaderTagType, StructAsBytes};
+use crate::{HeaderTagFlag, HeaderTagType};
 use core::fmt;
 use core::fmt::{Debug, Formatter};
 use core::mem::size_of;
@@ -91,4 +91,5 @@ impl Debug for RelocatableHeaderTag {
     }
 }
 
-impl StructAsBytes for RelocatableHeaderTag {}
+#[cfg(feature = "builder")]
+impl crate::StructAsBytes for RelocatableHeaderTag {}

--- a/multiboot2-header/src/uefi_bs.rs
+++ b/multiboot2-header/src/uefi_bs.rs
@@ -1,4 +1,4 @@
-use crate::{HeaderTagFlag, HeaderTagType, StructAsBytes};
+use crate::{HeaderTagFlag, HeaderTagType};
 use core::mem::size_of;
 
 /// This tag indicates that payload supports starting without terminating UEFI boot services.
@@ -31,4 +31,5 @@ impl EfiBootServiceHeaderTag {
     }
 }
 
-impl StructAsBytes for EfiBootServiceHeaderTag {}
+#[cfg(feature = "builder")]
+impl crate::StructAsBytes for EfiBootServiceHeaderTag {}


### PR DESCRIPTION
When I initially released this, I have overseen that this referenced `std`. This PR enables the crate in `no_std`-contexts and enables to disable the new `builder`-feature. When the latter is not included, the crate also does not need `alloc`.

This fixes #98 . #101  will ensure that such problems will not occur in the future.


This bumps the version to `v0.1.1`