### PR TITLE
publicly announce the MSRV is 1.52.1.

### DIFF
--- a/multiboot2-header/README.md
+++ b/multiboot2-header/README.md
@@ -67,6 +67,9 @@ static MULTIBOOT2_HDR: &[u8; 64] = include_bytes!("mb2_hdr_dump.bin");
 You may need a special linker script to place this in a LOAD segment with a file offset with less than 32768 bytes.
 See specification.
 
+## MSRV
+The MSRV is 1.52.1 stable.
+
 ## License & Contribution
 
 See main [README](https://github.com/rust-osdev/multiboot2/blob/main/README.md) file.

--- a/multiboot2-header/src/information_request.rs
+++ b/multiboot2-header/src/information_request.rs
@@ -160,7 +160,7 @@ impl InformationRequestHeaderTagBuilder {
 
         for tag in &self.irs {
             let bytes: [u8; 4] = (*tag as u32).to_ne_bytes();
-            data.extend(bytes);
+            data.extend(&bytes);
         }
 
         debug_assert_eq!(

--- a/multiboot2-header/src/lib.rs
+++ b/multiboot2-header/src/lib.rs
@@ -29,6 +29,9 @@
 //! println!("{:#?}", mb2_hdr);
 //!
 //! ```
+//!
+//! ## MSRV
+//! The MSRV is 1.52.1 stable.
 
 #![no_std]
 #![deny(rustdoc::all)]

--- a/multiboot2/README.md
+++ b/multiboot2/README.md
@@ -30,6 +30,9 @@ other fields  | variable
 
 All tags and the mbi itself are 8-byte aligned. The last tag must be the _end tag_, which is a tag of type `0` and size `8`.
 
+## MSRV
+The MSRV is 1.52.1 stable.
+
 ## License & Contribution
 
 See main [README](https://github.com/rust-osdev/multiboot2/blob/main/README.md) file.

--- a/multiboot2/src/lib.rs
+++ b/multiboot2/src/lib.rs
@@ -30,6 +30,9 @@
 //!     println!("{:?}", boot_info);
 //! }
 //! ```
+//!
+//! ## MSRV
+//! The MSRV is 1.52.1 stable.
 
 // this crate can use std in tests only
 #[cfg_attr(test, macro_use)]


### PR DESCRIPTION
I think this is relevant information that should be announced officially. This also helps us to identify breaking changes when we introduce new Rust functionality.