### PR TITLE
multiboot2-header: prepare v0.2.0

### DIFF
--- a/multiboot2-header/Cargo.toml
+++ b/multiboot2-header/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 Library with type definitions and parsing functions for Multiboot2 headers.
 This library is `no_std` and can be used in bootloaders.
 """
-version = "0.1.1"
+version = "0.2.0"
 authors = [
     "Philipp Schuster <phip1611@gmail.com>"
 ]

--- a/multiboot2-header/Changelog.md
+++ b/multiboot2-header/Changelog.md
@@ -1,7 +1,10 @@
 # CHANGELOG for crate `multiboot2-header`
 
 ## v0.2.0 (2022-05-03)
-- **breaking** renamed `EntryHeaderTag` to `EntryAddressHeaderTag`
+- **BREAKING** renamed `EntryHeaderTag` to `EntryAddressHeaderTag`
+- **BREAKING** some paths changed from `multiboot2_header::header` to `multiboot2_header::builder`
+   -> thus, import paths are much more logically now
+- internal code improvements
 
 ## v0.1.1 (2022-05-02)
 - fixed a bug that prevented the usage of the crate in `no_std` environments
@@ -12,4 +15,4 @@
 - initial release
 
 ## v0.0.0
-Empty release to save to name on crates.io
+Empty release to save the name on crates.io


### PR DESCRIPTION
Prepares release v0.2.0 for `multiboot2-header`-crate

Blockers: 
- [x] #109 
- [x] #111 