### PR TITLE
Multiboot2: More Safety for Getters of Strings from Tags (Prepare Release v0.14.0)

### DIFF
--- a/multiboot2/Cargo.toml
+++ b/multiboot2/Cargo.toml
@@ -6,7 +6,7 @@ Multiboot2-compliant bootloaders, like GRUB. It supports all tags from the speci
 including full support for the sections of ELF-64. This library is `no_std` and can be
 used in a Multiboot2-kernel.
 """
-version = "0.13.3"
+version = "0.14.0"
 authors = [
     "Philipp Oppermann <dev@phil-opp.com>",
     "Calvin Lee <cyrus296@gmail.com>",

--- a/multiboot2/Changelog.md
+++ b/multiboot2/Changelog.md
@@ -1,6 +1,20 @@
 # CHANGELOG for crate `multiboot2`
 
-## 0.13.3 (2022-05-03)
+## 0.14.0 (2022-05-xx)
+- **BREAKING CHANGES** \
+  This version includes a few small breaking changes that brings more safety when parsing strings from the
+  multiboot information structure.
+  - `BootLoaderNameTag::name` now returns a Result instead of just the value
+  - `CommandLineTag::command_line` now returns a Result instead of just the value
+  - `ModuleTag::cmdline` now returns a Result instead of just the value
+  - `RsdpV1Tag::signature` now returns a Result instead of an Option
+  - `RsdpV1Tag::oem_id` now returns a Result instead of an Option
+  - `RsdpV2Tag::signature` now returns a Result instead of an Option
+  - `RsdpV2Tag::oem_id` now returns a Result instead of an Option
+- internal code improvements
+
+
+## 0.13.3 (2022-06-03)
 - impl `Send` for `BootInformation`
 
 ## 0.13.2 (2022-05-02)

--- a/multiboot2/src/command_line.rs
+++ b/multiboot2/src/command_line.rs
@@ -1,4 +1,9 @@
+//! Module for [CommandLineTag].
+
 use crate::TagType;
+use core::mem;
+use core::slice;
+use core::str::Utf8Error;
 
 /// This tag contains the command line string.
 ///
@@ -9,11 +14,14 @@ use crate::TagType;
 pub struct CommandLineTag {
     typ: TagType,
     size: u32,
+    /// Null-terminated UTF-8 string
     string: u8,
 }
 
 impl CommandLineTag {
     /// Read the command line string that is being passed to the booting kernel.
+    /// This is an null-terminated UTF-8 string. If this returns `Err` then perhaps the memory
+    /// is invalid or the bootloader doesn't follow the spec.
     ///
     /// # Examples
     ///
@@ -23,11 +31,9 @@ impl CommandLineTag {
     ///     assert_eq!("/bootarg", command_line);
     /// }
     /// ```
-    pub fn command_line(&self) -> &str {
-        use core::{mem, slice, str};
-        unsafe {
-            let strlen = self.size as usize - mem::size_of::<CommandLineTag>();
-            str::from_utf8_unchecked(slice::from_raw_parts((&self.string) as *const u8, strlen))
-        }
+    pub fn command_line(&self) -> Result<&str, Utf8Error> {
+        let strlen = self.size as usize - mem::size_of::<CommandLineTag>();
+        let bytes = unsafe { slice::from_raw_parts((&self.string) as *const u8, strlen) };
+        core::str::from_utf8(bytes)
     }
 }

--- a/multiboot2/src/elf_sections.rs
+++ b/multiboot2/src/elf_sections.rs
@@ -190,6 +190,8 @@ impl ElfSection {
         use core::{slice, str};
 
         let name_ptr = unsafe { self.string_table().offset(self.get().name_index() as isize) };
+
+        // strlen without null byte
         let strlen = {
             let mut len = 0;
             while unsafe { *name_ptr.offset(len) } != 0 {

--- a/multiboot2/src/framebuffer.rs
+++ b/multiboot2/src/framebuffer.rs
@@ -3,7 +3,7 @@ use crate::Reader;
 use core::slice;
 
 /// The VBE Framebuffer information Tag.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct FramebufferTag<'a> {
     /// Contains framebuffer physical address.
     ///
@@ -29,7 +29,7 @@ pub struct FramebufferTag<'a> {
 }
 
 /// The type of framebuffer.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum FramebufferType<'a> {
     /// Indexed color.
     Indexed {
@@ -55,7 +55,7 @@ pub enum FramebufferType<'a> {
 }
 
 /// An RGB color type field.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct FramebufferField {
     /// Color field position.
     pub position: u8,
@@ -65,7 +65,7 @@ pub struct FramebufferField {
 }
 
 /// A framebuffer color descriptor in the palette.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(C, packed)] // only repr(C) would add unwanted padding at the end
 pub struct FramebufferColor {
     /// The Red component of the color.

--- a/multiboot2/src/lib.rs
+++ b/multiboot2/src/lib.rs
@@ -352,14 +352,14 @@ impl fmt::Debug for BootInformation {
                 "boot_loader_name_tag",
                 &self
                     .boot_loader_name_tag()
-                    .map(|x| x.name())
+                    .and_then(|x| x.name().ok())
                     .unwrap_or("<unknown>"),
             )
             .field(
                 "command_line",
                 &self
                     .command_line_tag()
-                    .map(|x| x.command_line())
+                    .and_then(|x| x.command_line().ok())
                     .unwrap_or(""),
             )
             .field("memory_areas", &self.memory_map_tag())
@@ -532,7 +532,13 @@ mod tests {
         assert!(bi.elf_sections_tag().is_none());
         assert!(bi.memory_map_tag().is_none());
         assert!(bi.module_tags().next().is_none());
-        assert_eq!("name", bi.boot_loader_name_tag().unwrap().name());
+        assert_eq!(
+            "name",
+            bi.boot_loader_name_tag()
+                .expect("tag must be present")
+                .name()
+                .expect("must be valid utf8")
+        );
         assert!(bi.command_line_tag().is_none());
     }
 
@@ -1231,9 +1237,18 @@ mod tests {
         assert!(bi.module_tags().next().is_none());
         assert_eq!(
             "GRUB 2.02~beta3-5",
-            bi.boot_loader_name_tag().unwrap().name()
+            bi.boot_loader_name_tag()
+                .expect("tag must be present")
+                .name()
+                .expect("must be valid utf-8")
         );
-        assert_eq!("", bi.command_line_tag().unwrap().command_line());
+        assert_eq!(
+            "",
+            bi.command_line_tag()
+                .expect("tag must present")
+                .command_line()
+                .expect("must be valid utf-8")
+        );
 
         // Test the Framebuffer tag
         let fbi = bi.framebuffer_tag().unwrap();

--- a/multiboot2/src/rsdp.rs
+++ b/multiboot2/src/rsdp.rs
@@ -11,6 +11,7 @@
 use crate::TagType;
 use core::slice;
 use core::str;
+use core::str::Utf8Error;
 
 const RSDPV1_LENGTH: usize = 20;
 
@@ -31,8 +32,8 @@ impl RsdpV1Tag {
     /// The "RSD PTR " marker singature.
     ///
     /// This is originally a 8-byte C string (not null terminated!) that must contain "RSD PTR "
-    pub fn signature(&self) -> Option<&str> {
-        str::from_utf8(&self.signature).ok()
+    pub fn signature(&self) -> Result<&str, Utf8Error> {
+        str::from_utf8(&self.signature)
     }
 
     /// Validation of the RSDPv1 checksum
@@ -46,8 +47,8 @@ impl RsdpV1Tag {
     }
 
     /// An OEM-supplied string that identifies the OEM.
-    pub fn oem_id(&self) -> Option<&str> {
-        str::from_utf8(&self.oem_id).ok()
+    pub fn oem_id(&self) -> Result<&str, Utf8Error> {
+        str::from_utf8(&self.oem_id)
     }
 
     /// The revision of the ACPI.
@@ -79,11 +80,11 @@ pub struct RsdpV2Tag {
 }
 
 impl RsdpV2Tag {
-    /// The "RSD PTR " marker singature.
+    /// The "RSD PTR " marker signature.
     ///
     /// This is originally a 8-byte C string (not null terminated!) that must contain "RSD PTR ".
-    pub fn signature(&self) -> Option<&str> {
-        str::from_utf8(&self.signature).ok()
+    pub fn signature(&self) -> Result<&str, Utf8Error> {
+        str::from_utf8(&self.signature)
     }
 
     /// Validation of the RSDPv2 extended checksum
@@ -98,8 +99,8 @@ impl RsdpV2Tag {
     }
 
     /// An OEM-supplied string that identifies the OEM.
-    pub fn oem_id(&self) -> Option<&str> {
-        str::from_utf8(&self.oem_id).ok()
+    pub fn oem_id(&self) -> Result<&str, Utf8Error> {
+        str::from_utf8(&self.oem_id)
     }
 
     /// The revision of the ACPI.

--- a/multiboot2/src/vbe_info.rs
+++ b/multiboot2/src/vbe_info.rs
@@ -234,7 +234,7 @@ impl fmt::Debug for VBEModeInfo {
 /// A VBE colour field.
 ///
 /// Descirbes the size and position of some colour capability.
-#[derive(Debug, PartialEq, Copy, Clone)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
 #[repr(C, packed)]
 pub struct VBEField {
     /// The size, in bits, of the color components of a direct color pixel.
@@ -327,7 +327,7 @@ bitflags! {
 }
 
 /// The MemoryModel field specifies the general type of memory organization used in modes.
-#[derive(Debug, PartialEq, Copy, Clone)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
 #[repr(u8)]
 #[allow(missing_docs)]
 pub enum VBEMemoryModel {


### PR DESCRIPTION
Improve safety when parsing strings from Tags + general code improvements. 