### PR TITLE
multiboot2: Fix EFI Memory Map 'last_area' calculation

### DIFF
--- a/multiboot2-header/src/builder/information_request.rs
+++ b/multiboot2-header/src/builder/information_request.rs
@@ -21,7 +21,7 @@ pub struct InformationRequestHeaderTagBuilder {
 #[cfg(feature = "builder")]
 impl InformationRequestHeaderTagBuilder {
     /// New builder.
-    pub fn new(flag: HeaderTagFlag) -> Self {
+    pub const fn new(flag: HeaderTagFlag) -> Self {
         Self {
             irs: BTreeSet::new(),
             flag,

--- a/multiboot2-header/src/header.rs
+++ b/multiboot2-header/src/header.rs
@@ -47,8 +47,7 @@ impl<'a> Multiboot2Header<'a> {
         assert_eq!(
             reference.header_magic(),
             MULTIBOOT2_HEADER_MAGIC,
-            "The Multiboot2 header must contain the MULTIBOOT2_HEADER_MAGIC={:x}",
-            MULTIBOOT2_HEADER_MAGIC
+            "The Multiboot2 header must contain the MULTIBOOT2_HEADER_MAGIC={MULTIBOOT2_HEADER_MAGIC:x}"
         );
         assert!(
             reference.verify_checksum(),

--- a/multiboot2/src/lib.rs
+++ b/multiboot2/src/lib.rs
@@ -1416,12 +1416,22 @@ mod tests {
     }
 
     #[test]
+    /// Compile time test for `MemoryMapTag`.
+    fn e820_memory_map_tag_size() {
+        use super::MemoryMapTag;
+        unsafe {
+            // `MemoryMapTag` is 16 bytes without the 1st entry
+            core::mem::transmute::<[u8; 16], MemoryMapTag>([0u8; 16]);
+        }
+    }
+
+    #[test]
     /// Compile time test for `EFIMemoryMapTag`.
     fn efi_memory_map_tag_size() {
         use super::EFIMemoryMapTag;
         unsafe {
-            // `EFIMemoryMapTag` is 16 bytes + `EFIMemoryDesc` is 40 bytes.
-            core::mem::transmute::<[u8; 56], EFIMemoryMapTag>([0u8; 56]);
+            // `EFIMemoryMapTag` is 16 bytes without the 1st entry
+            core::mem::transmute::<[u8; 16], EFIMemoryMapTag>([0u8; 16]);
         }
     }
 }


### PR DESCRIPTION
Correct EFI 'last_area' calculation and align it to be more similar the E820 version.

(Previously, iterating the EFI Memory map resulted in a superfluous entry as it ran over the next tag)