### PR TITLE
ci: cache per rust version

### DIFF
--- a/.github/workflows/_build-rust.yml
+++ b/.github/workflows/_build-rust.yml
@@ -52,7 +52,8 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-${{ inputs.rust-version }}
+          # We do not have a Cargo.lock here, so I hash Cargo.toml
+          key: ${{ runner.os }}-rust-${{ inputs.rust-version }}-cargo-${{ hashFiles('**/Cargo.toml') }}
           restore-keys: ${{ runner.os }}-cargo-${{ inputs.rust-version }}
       - run: cargo version
       - name: Code Formatting

--- a/.github/workflows/_build-rust.yml
+++ b/.github/workflows/_build-rust.yml
@@ -52,8 +52,8 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-${{ inputs.rust-version }}
+          restore-keys: ${{ runner.os }}-cargo-${{ inputs.rust-version }}
       - run: cargo version
       - name: Code Formatting
         if: ${{ inputs.do-style-check }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -80,3 +80,12 @@ jobs:
       rust-version: stable
       do-style-check: true
       do-test: false
+
+  style_nightly:
+    name: style (nightly)
+    needs: build_nightly
+    uses: ./.github/workflows/_build-rust.yml
+    with:
+      rust-version: nightly
+      do-style-check: true
+      do-test: false

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,66 +15,66 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build_multiboot2_msrv:
+  build_msrv:
     name: build (msrv)
     uses: ./.github/workflows/_build-rust.yml
     with:
       rust-version: 1.56.1
       do-style-check: false
 
-  build_multiboot2_stable:
+  build_stable:
     name: build (stable)
     uses: ./.github/workflows/_build-rust.yml
     with:
       rust-version: stable
       do-style-check: false
 
-  build_multiboot2_nightly:
+  build_nightly:
     name: build (nightly)
     uses: ./.github/workflows/_build-rust.yml
     with:
       rust-version: nightly
       do-style-check: false
 
-  build_nostd_multiboot2_msrv:
+  build_nostd_msrv:
     name: build no_std (msrv)
-    needs: build_multiboot2_msrv
+    needs: build_msrv
     uses: ./.github/workflows/_build-rust.yml
     with:
       rust-version: 1.56.1
       do-style-check: false
       rust-target: thumbv7em-none-eabihf
 
-  build_nostd_multiboot2_stable:
+  build_nostd_stable:
     name: build no_std (stable)
-    needs: build_multiboot2_stable
+    needs: build_stable
     uses: ./.github/workflows/_build-rust.yml
     with:
       rust-version: stable
       do-style-check: false
       rust-target: thumbv7em-none-eabihf
 
-  build_nostd_multiboot2_nightly:
+  build_nostd_nightly:
     name: build no_std (nightly)
-    needs: build_multiboot2_nightly
+    needs: build_nightly
     uses: ./.github/workflows/_build-rust.yml
     with:
       rust-version: nightly
       do-style-check: false
       rust-target: thumbv7em-none-eabihf
 
-  style_multiboot2_msrv:
+  style_msrv:
     name: style (msrv)
-    needs: build_multiboot2_msrv
+    needs: build_msrv
     uses: ./.github/workflows/_build-rust.yml
     with:
       rust-version: 1.56.1
       do-style-check: true
       do-test: false
 
-  style_multiboot2_stable:
+  style_stable:
     name: style (stable)
-    needs: build_multiboot2_stable
+    needs: build_stable
     uses: ./.github/workflows/_build-rust.yml
     with:
       rust-version: stable

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,6 +38,7 @@ jobs:
 
   build_nostd_multiboot2_msrv:
     name: build no_std (msrv)
+    needs: build_multiboot2_msrv
     uses: ./.github/workflows/_build-rust.yml
     with:
       rust-version: 1.56.1
@@ -46,6 +47,7 @@ jobs:
 
   build_nostd_multiboot2_stable:
     name: build no_std (stable)
+    needs: build_multiboot2_stable
     uses: ./.github/workflows/_build-rust.yml
     with:
       rust-version: stable
@@ -54,6 +56,7 @@ jobs:
 
   build_nostd_multiboot2_nightly:
     name: build no_std (nightly)
+    needs: build_multiboot2_nightly
     uses: ./.github/workflows/_build-rust.yml
     with:
       rust-version: nightly
@@ -62,6 +65,7 @@ jobs:
 
   style_multiboot2_msrv:
     name: style (msrv)
+    needs: build_multiboot2_msrv
     uses: ./.github/workflows/_build-rust.yml
     with:
       rust-version: 1.56.1
@@ -70,6 +74,7 @@ jobs:
 
   style_multiboot2_stable:
     name: style (stable)
+    needs: build_multiboot2_stable
     uses: ./.github/workflows/_build-rust.yml
     with:
       rust-version: stable

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,28 +16,28 @@ env:
 
 jobs:
   build_multiboot2_msrv:
-    name: "build (msrv)"
+    name: build (msrv)
     uses: ./.github/workflows/_build-rust.yml
     with:
       rust-version: 1.56.1
       do-style-check: false
 
   build_multiboot2_stable:
-    name: "build (stable)"
+    name: build (stable)
     uses: ./.github/workflows/_build-rust.yml
     with:
       rust-version: stable
       do-style-check: false
 
   build_multiboot2_nightly:
-    name: "build (nightly)"
+    name: build (nightly)
     uses: ./.github/workflows/_build-rust.yml
     with:
       rust-version: nightly
       do-style-check: false
 
   build_nostd_multiboot2_msrv:
-    name: "build no_std (msrv)"
+    name: build no_std (msrv)
     uses: ./.github/workflows/_build-rust.yml
     with:
       rust-version: 1.56.1
@@ -45,7 +45,7 @@ jobs:
       rust-target: thumbv7em-none-eabihf
 
   build_nostd_multiboot2_stable:
-    name: "build no_std  (stable)"
+    name: build no_std (stable)
     uses: ./.github/workflows/_build-rust.yml
     with:
       rust-version: stable
@@ -53,7 +53,7 @@ jobs:
       rust-target: thumbv7em-none-eabihf
 
   build_nostd_multiboot2_nightly:
-    name: "build no_std  (nightly)"
+    name: build no_std (nightly)
     uses: ./.github/workflows/_build-rust.yml
     with:
       rust-version: nightly
@@ -61,7 +61,7 @@ jobs:
       rust-target: thumbv7em-none-eabihf
 
   style_multiboot2_msrv:
-    name: "style (msrv)"
+    name: style (msrv)
     uses: ./.github/workflows/_build-rust.yml
     with:
       rust-version: 1.56.1
@@ -69,7 +69,7 @@ jobs:
       do-test: false
 
   style_multiboot2_stable:
-    name: "style (stable)"
+    name: style (stable)
     uses: ./.github/workflows/_build-rust.yml
     with:
       rust-version: stable


### PR DESCRIPTION
cache per rust version. This is necessary to make the Rust cache effective. 

CI is now super cool, fast, and wonderfully over-engineered and still nice 😄 

![image](https://user-images.githubusercontent.com/5737016/225951532-c7ebbd9d-eaf0-4d19-acec-dc2ad2ecb5b0.png)

![image](https://user-images.githubusercontent.com/5737016/225951587-2d64d39d-9542-483d-ae8e-c27141901a42.png)


