### PR TITLE
Add a builder to multiboot2

### DIFF
--- a/multiboot2-header/src/relocatable.rs
+++ b/multiboot2-header/src/relocatable.rs
@@ -8,7 +8,7 @@ use core::mem::size_of;
 /// but not lower than min addr and ‘2’ means load image at highest possible
 /// address but not higher than max addr.
 #[repr(u32)]
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub enum RelocatableHeaderTagPreference {
     /// Let boot loader decide.
     None = 0,

--- a/multiboot2/Cargo.toml
+++ b/multiboot2/Cargo.toml
@@ -32,7 +32,10 @@ repository = "https://github.com/rust-osdev/multiboot2"
 documentation = "https://docs.rs/multiboot2"
 
 [features]
-default = []
+# by default, builder is included
+default = ["builder"]
+std = []
+builder = ["std"]
 # Nightly-only features that will eventually be stabilized.
 unstable = []
 

--- a/multiboot2/src/boot_loader_name.rs
+++ b/multiboot2/src/boot_loader_name.rs
@@ -1,7 +1,12 @@
-use crate::TagTrait;
-use crate::{Tag, TagTypeId};
+use crate::{Tag, TagTrait, TagType, TagTypeId};
 use core::fmt::{Debug, Formatter};
+use core::mem::size_of;
 use core::str::Utf8Error;
+
+#[cfg(feature = "builder")]
+use {crate::builder::boxed_dst_tag, alloc::boxed::Box, alloc::vec::Vec};
+
+const METADATA_SIZE: usize = size_of::<TagTypeId>() + size_of::<u32>();
 
 /// The bootloader name tag.
 #[derive(ptr_meta::Pointee)]
@@ -14,6 +19,13 @@ pub struct BootLoaderNameTag {
 }
 
 impl BootLoaderNameTag {
+    #[cfg(feature = "builder")]
+    pub fn new(name: &str) -> Box<Self> {
+        let mut bytes: Vec<_> = name.bytes().collect();
+        bytes.push(0);
+        boxed_dst_tag(TagType::BootLoaderName, &bytes)
+    }
+
     /// Reads the name of the bootloader that is booting the kernel as Rust
     /// string slice without the null-byte.
     ///
@@ -46,10 +58,8 @@ impl Debug for BootLoaderNameTag {
 
 impl TagTrait for BootLoaderNameTag {
     fn dst_size(base_tag: &Tag) -> usize {
-        // The size of the sized portion of the bootloader name tag.
-        let tag_base_size = 8;
-        assert!(base_tag.size >= 8);
-        base_tag.size as usize - tag_base_size
+        assert!(base_tag.size as usize >= METADATA_SIZE);
+        base_tag.size as usize - METADATA_SIZE
     }
 }
 

--- a/multiboot2/src/builder/information.rs
+++ b/multiboot2/src/builder/information.rs
@@ -2,7 +2,7 @@
 use crate::builder::traits::StructAsBytes;
 use crate::{
     BasicMemoryInfoTag, BootLoaderNameTag, CommandLineTag, ElfSectionsTag, FramebufferTag,
-    ModuleTag,
+    MemoryMapTag, ModuleTag,
 };
 
 use alloc::boxed::Box;
@@ -18,6 +18,7 @@ pub struct Multiboot2InformationBuilder {
     command_line_tag: Option<Box<CommandLineTag>>,
     elf_sections_tag: Option<Box<ElfSectionsTag>>,
     framebuffer_tag: Option<Box<FramebufferTag>>,
+    memory_map_tag: Option<Box<MemoryMapTag>>,
     module_tags: Vec<Box<ModuleTag>>,
 }
 
@@ -29,6 +30,7 @@ impl Multiboot2InformationBuilder {
             command_line_tag: None,
             elf_sections_tag: None,
             framebuffer_tag: None,
+            memory_map_tag: None,
             module_tags: Vec::new(),
         }
     }
@@ -51,6 +53,10 @@ impl Multiboot2InformationBuilder {
 
     pub fn framebuffer_tag(&mut self, framebuffer_tag: Box<FramebufferTag>) {
         self.framebuffer_tag = Some(framebuffer_tag);
+    }
+
+    pub fn memory_map_tag(&mut self, memory_map_tag: Box<MemoryMapTag>) {
+        self.memory_map_tag = Some(memory_map_tag);
     }
 
     pub fn add_module_tag(&mut self, module_tag: Box<ModuleTag>) {

--- a/multiboot2/src/builder/information.rs
+++ b/multiboot2/src/builder/information.rs
@@ -1,8 +1,8 @@
 //! Exports item [`Multiboot2InformationBuilder`].
 use crate::builder::traits::StructAsBytes;
 use crate::{
-    BasicMemoryInfoTag, BootInformationInner, BootLoaderNameTag, CommandLineTag, ElfSectionsTag,
-    EndTag, FramebufferTag, MemoryMapTag, ModuleTag,
+    BasicMemoryInfoTag, BootInformationInner, BootLoaderNameTag, CommandLineTag, EFISdt32,
+    EFISdt64, ElfSectionsTag, EndTag, FramebufferTag, MemoryMapTag, ModuleTag,
 };
 
 use alloc::boxed::Box;
@@ -21,6 +21,8 @@ pub struct Multiboot2InformationBuilder {
     framebuffer_tag: Option<Box<FramebufferTag>>,
     memory_map_tag: Option<Box<MemoryMapTag>>,
     module_tags: Vec<Box<ModuleTag>>,
+    efisdt32: Option<EFISdt32>,
+    efisdt64: Option<EFISdt64>,
 }
 
 impl Multiboot2InformationBuilder {
@@ -29,6 +31,8 @@ impl Multiboot2InformationBuilder {
             basic_memory_info_tag: None,
             boot_loader_name_tag: None,
             command_line_tag: None,
+            efisdt32: None,
+            efisdt64: None,
             elf_sections_tag: None,
             framebuffer_tag: None,
             memory_map_tag: None,
@@ -64,6 +68,12 @@ impl Multiboot2InformationBuilder {
             len += Self::size_or_up_aligned(tag.byte_size())
         }
         if let Some(tag) = &self.command_line_tag {
+            len += Self::size_or_up_aligned(tag.byte_size())
+        }
+        if let Some(tag) = &self.efisdt32 {
+            len += Self::size_or_up_aligned(tag.byte_size())
+        }
+        if let Some(tag) = &self.efisdt64 {
             len += Self::size_or_up_aligned(tag.byte_size())
         }
         if let Some(tag) = &self.elf_sections_tag {
@@ -117,6 +127,12 @@ impl Multiboot2InformationBuilder {
         if let Some(tag) = self.command_line_tag.as_ref() {
             Self::build_add_bytes(&mut data, &tag.struct_as_bytes(), false)
         }
+        if let Some(tag) = self.efisdt32.as_ref() {
+            Self::build_add_bytes(&mut data, &tag.struct_as_bytes(), false)
+        }
+        if let Some(tag) = self.efisdt64.as_ref() {
+            Self::build_add_bytes(&mut data, &tag.struct_as_bytes(), false)
+        }
         if let Some(tag) = self.elf_sections_tag.as_ref() {
             Self::build_add_bytes(&mut data, &tag.struct_as_bytes(), false)
         }
@@ -145,6 +161,14 @@ impl Multiboot2InformationBuilder {
 
     pub fn command_line_tag(&mut self, command_line_tag: Box<CommandLineTag>) {
         self.command_line_tag = Some(command_line_tag);
+    }
+
+    pub fn efisdt32(&mut self, efisdt32: EFISdt32) {
+        self.efisdt32 = Some(efisdt32);
+    }
+
+    pub fn efisdt64(&mut self, efisdt64: EFISdt64) {
+        self.efisdt64 = Some(efisdt64);
     }
 
     pub fn elf_sections_tag(&mut self, elf_sections_tag: Box<ElfSectionsTag>) {

--- a/multiboot2/src/builder/information.rs
+++ b/multiboot2/src/builder/information.rs
@@ -2,7 +2,8 @@
 use crate::builder::traits::StructAsBytes;
 use crate::{
     BasicMemoryInfoTag, BootInformationInner, BootLoaderNameTag, CommandLineTag, EFISdt32,
-    EFISdt64, ElfSectionsTag, EndTag, FramebufferTag, MemoryMapTag, ModuleTag, SmbiosTag,
+    EFISdt64, ElfSectionsTag, EndTag, FramebufferTag, MemoryMapTag, ModuleTag, RsdpV1Tag,
+    RsdpV2Tag, SmbiosTag,
 };
 
 use alloc::boxed::Box;
@@ -23,6 +24,8 @@ pub struct Multiboot2InformationBuilder {
     module_tags: Vec<Box<ModuleTag>>,
     efisdt32: Option<EFISdt32>,
     efisdt64: Option<EFISdt64>,
+    rsdp_v1_tag: Option<RsdpV1Tag>,
+    rsdp_v2_tag: Option<RsdpV2Tag>,
     smbios_tags: Vec<Box<SmbiosTag>>,
 }
 
@@ -38,6 +41,8 @@ impl Multiboot2InformationBuilder {
             framebuffer_tag: None,
             memory_map_tag: None,
             module_tags: Vec::new(),
+            rsdp_v1_tag: None,
+            rsdp_v2_tag: None,
             smbios_tags: Vec::new(),
         }
     }
@@ -88,6 +93,12 @@ impl Multiboot2InformationBuilder {
             len += Self::size_or_up_aligned(tag.byte_size())
         }
         for tag in &self.module_tags {
+            len += Self::size_or_up_aligned(tag.byte_size())
+        }
+        if let Some(tag) = &self.rsdp_v1_tag {
+            len += Self::size_or_up_aligned(tag.byte_size())
+        }
+        if let Some(tag) = &self.rsdp_v2_tag {
             len += Self::size_or_up_aligned(tag.byte_size())
         }
         for tag in &self.smbios_tags {
@@ -150,6 +161,12 @@ impl Multiboot2InformationBuilder {
         for tag in self.module_tags {
             Self::build_add_bytes(&mut data, &tag.struct_as_bytes(), false)
         }
+        if let Some(tag) = self.rsdp_v1_tag.as_ref() {
+            Self::build_add_bytes(&mut data, &tag.struct_as_bytes(), false)
+        }
+        if let Some(tag) = self.rsdp_v2_tag.as_ref() {
+            Self::build_add_bytes(&mut data, &tag.struct_as_bytes(), false)
+        }
         for tag in self.smbios_tags {
             Self::build_add_bytes(&mut data, &tag.struct_as_bytes(), false)
         }
@@ -193,6 +210,14 @@ impl Multiboot2InformationBuilder {
 
     pub fn add_module_tag(&mut self, module_tag: Box<ModuleTag>) {
         self.module_tags.push(module_tag);
+    }
+
+    pub fn rsdp_v1_tag(&mut self, rsdp_v1_tag: RsdpV1Tag) {
+        self.rsdp_v1_tag = Some(rsdp_v1_tag);
+    }
+
+    pub fn rsdp_v2_tag(&mut self, rsdp_v2_tag: RsdpV2Tag) {
+        self.rsdp_v2_tag = Some(rsdp_v2_tag);
     }
 
     pub fn add_smbios_tag(&mut self, smbios_tag: Box<SmbiosTag>) {

--- a/multiboot2/src/builder/information.rs
+++ b/multiboot2/src/builder/information.rs
@@ -1,5 +1,6 @@
 //! Exports item [`Multiboot2InformationBuilder`].
-use crate::{builder::traits::StructAsBytes, CommandLineTag, ModuleTag};
+use crate::builder::traits::StructAsBytes;
+use crate::{CommandLineTag, ElfSectionsTag, ModuleTag};
 
 use alloc::boxed::Box;
 use alloc::vec::Vec;
@@ -10,6 +11,7 @@ use alloc::vec::Vec;
 #[derive(Debug)]
 pub struct Multiboot2InformationBuilder {
     command_line_tag: Option<Box<CommandLineTag>>,
+    elf_sections_tag: Option<Box<ElfSectionsTag>>,
     module_tags: Vec<Box<ModuleTag>>,
 }
 
@@ -17,12 +19,17 @@ impl Multiboot2InformationBuilder {
     pub const fn new() -> Self {
         Self {
             command_line_tag: None,
+            elf_sections_tag: None,
             module_tags: Vec::new(),
         }
     }
 
     pub fn command_line_tag(&mut self, command_line_tag: Box<CommandLineTag>) {
         self.command_line_tag = Some(command_line_tag);
+    }
+
+    pub fn elf_sections_tag(&mut self, elf_sections_tag: Box<ElfSectionsTag>) {
+        self.elf_sections_tag = Some(elf_sections_tag);
     }
 
     pub fn add_module_tag(&mut self, module_tag: Box<ModuleTag>) {

--- a/multiboot2/src/builder/information.rs
+++ b/multiboot2/src/builder/information.rs
@@ -1,9 +1,9 @@
 //! Exports item [`Multiboot2InformationBuilder`].
 use crate::builder::traits::StructAsBytes;
 use crate::{
-    BasicMemoryInfoTag, BootInformationInner, BootLoaderNameTag, CommandLineTag, EFIMemoryMapTag,
-    EFISdt32, EFISdt64, ElfSectionsTag, EndTag, FramebufferTag, MemoryMapTag, ModuleTag, RsdpV1Tag,
-    RsdpV2Tag, SmbiosTag,
+    BasicMemoryInfoTag, BootInformationInner, BootLoaderNameTag, CommandLineTag,
+    EFIBootServicesNotExited, EFIMemoryMapTag, EFISdt32, EFISdt64, ElfSectionsTag, EndTag,
+    FramebufferTag, MemoryMapTag, ModuleTag, RsdpV1Tag, RsdpV2Tag, SmbiosTag,
 };
 
 use alloc::boxed::Box;
@@ -18,6 +18,7 @@ pub struct Multiboot2InformationBuilder {
     basic_memory_info_tag: Option<BasicMemoryInfoTag>,
     boot_loader_name_tag: Option<Box<BootLoaderNameTag>>,
     command_line_tag: Option<Box<CommandLineTag>>,
+    efi_boot_services_not_exited: Option<EFIBootServicesNotExited>,
     efi_memory_map_tag: Option<Box<EFIMemoryMapTag>>,
     elf_sections_tag: Option<Box<ElfSectionsTag>>,
     framebuffer_tag: Option<Box<FramebufferTag>>,
@@ -38,6 +39,7 @@ impl Multiboot2InformationBuilder {
             command_line_tag: None,
             efisdt32: None,
             efisdt64: None,
+            efi_boot_services_not_exited: None,
             efi_memory_map_tag: None,
             elf_sections_tag: None,
             framebuffer_tag: None,
@@ -83,6 +85,9 @@ impl Multiboot2InformationBuilder {
             len += Self::size_or_up_aligned(tag.byte_size())
         }
         if let Some(tag) = &self.efisdt64 {
+            len += Self::size_or_up_aligned(tag.byte_size())
+        }
+        if let Some(tag) = &self.efi_boot_services_not_exited {
             len += Self::size_or_up_aligned(tag.byte_size())
         }
         if let Some(tag) = &self.efi_memory_map_tag {
@@ -154,6 +159,9 @@ impl Multiboot2InformationBuilder {
         if let Some(tag) = self.efisdt64.as_ref() {
             Self::build_add_bytes(&mut data, &tag.struct_as_bytes(), false)
         }
+        if let Some(tag) = self.efi_boot_services_not_exited.as_ref() {
+            Self::build_add_bytes(&mut data, &tag.struct_as_bytes(), false)
+        }
         if let Some(tag) = self.efi_memory_map_tag.as_ref() {
             Self::build_add_bytes(&mut data, &tag.struct_as_bytes(), false)
         }
@@ -202,6 +210,10 @@ impl Multiboot2InformationBuilder {
 
     pub fn efisdt64(&mut self, efisdt64: EFISdt64) {
         self.efisdt64 = Some(efisdt64);
+    }
+
+    pub fn efi_boot_services_not_exited(&mut self) {
+        self.efi_boot_services_not_exited = Some(EFIBootServicesNotExited::new());
     }
 
     pub fn efi_memory_map_tag(&mut self, efi_memory_map_tag: Box<EFIMemoryMapTag>) {

--- a/multiboot2/src/builder/information.rs
+++ b/multiboot2/src/builder/information.rs
@@ -2,8 +2,9 @@
 use crate::builder::traits::StructAsBytes;
 use crate::{
     BasicMemoryInfoTag, BootInformationInner, BootLoaderNameTag, CommandLineTag,
-    EFIBootServicesNotExited, EFIMemoryMapTag, EFISdt32, EFISdt64, ElfSectionsTag, EndTag,
-    FramebufferTag, MemoryMapTag, ModuleTag, RsdpV1Tag, RsdpV2Tag, SmbiosTag,
+    EFIBootServicesNotExited, EFIImageHandle32, EFIImageHandle64, EFIMemoryMapTag, EFISdt32,
+    EFISdt64, ElfSectionsTag, EndTag, FramebufferTag, MemoryMapTag, ModuleTag, RsdpV1Tag,
+    RsdpV2Tag, SmbiosTag,
 };
 
 use alloc::boxed::Box;
@@ -19,6 +20,8 @@ pub struct Multiboot2InformationBuilder {
     boot_loader_name_tag: Option<Box<BootLoaderNameTag>>,
     command_line_tag: Option<Box<CommandLineTag>>,
     efi_boot_services_not_exited: Option<EFIBootServicesNotExited>,
+    efi_image_handle32: Option<EFIImageHandle32>,
+    efi_image_handle64: Option<EFIImageHandle64>,
     efi_memory_map_tag: Option<Box<EFIMemoryMapTag>>,
     elf_sections_tag: Option<Box<ElfSectionsTag>>,
     framebuffer_tag: Option<Box<FramebufferTag>>,
@@ -40,6 +43,8 @@ impl Multiboot2InformationBuilder {
             efisdt32: None,
             efisdt64: None,
             efi_boot_services_not_exited: None,
+            efi_image_handle32: None,
+            efi_image_handle64: None,
             efi_memory_map_tag: None,
             elf_sections_tag: None,
             framebuffer_tag: None,
@@ -88,6 +93,12 @@ impl Multiboot2InformationBuilder {
             len += Self::size_or_up_aligned(tag.byte_size())
         }
         if let Some(tag) = &self.efi_boot_services_not_exited {
+            len += Self::size_or_up_aligned(tag.byte_size())
+        }
+        if let Some(tag) = &self.efi_image_handle32 {
+            len += Self::size_or_up_aligned(tag.byte_size())
+        }
+        if let Some(tag) = &self.efi_image_handle64 {
             len += Self::size_or_up_aligned(tag.byte_size())
         }
         if let Some(tag) = &self.efi_memory_map_tag {
@@ -162,6 +173,12 @@ impl Multiboot2InformationBuilder {
         if let Some(tag) = self.efi_boot_services_not_exited.as_ref() {
             Self::build_add_bytes(&mut data, &tag.struct_as_bytes(), false)
         }
+        if let Some(tag) = self.efi_image_handle32.as_ref() {
+            Self::build_add_bytes(&mut data, &tag.struct_as_bytes(), false)
+        }
+        if let Some(tag) = self.efi_image_handle64.as_ref() {
+            Self::build_add_bytes(&mut data, &tag.struct_as_bytes(), false)
+        }
         if let Some(tag) = self.efi_memory_map_tag.as_ref() {
             Self::build_add_bytes(&mut data, &tag.struct_as_bytes(), false)
         }
@@ -214,6 +231,14 @@ impl Multiboot2InformationBuilder {
 
     pub fn efi_boot_services_not_exited(&mut self) {
         self.efi_boot_services_not_exited = Some(EFIBootServicesNotExited::new());
+    }
+
+    pub fn efi_image_handle32(&mut self, efi_image_handle32: EFIImageHandle32) {
+        self.efi_image_handle32 = Some(efi_image_handle32);
+    }
+
+    pub fn efi_image_handle64(&mut self, efi_image_handle64: EFIImageHandle64) {
+        self.efi_image_handle64 = Some(efi_image_handle64);
     }
 
     pub fn efi_memory_map_tag(&mut self, efi_memory_map_tag: Box<EFIMemoryMapTag>) {

--- a/multiboot2/src/builder/information.rs
+++ b/multiboot2/src/builder/information.rs
@@ -1,6 +1,6 @@
 //! Exports item [`Multiboot2InformationBuilder`].
 use crate::builder::traits::StructAsBytes;
-use crate::{BootLoaderNameTag, CommandLineTag, ElfSectionsTag, ModuleTag};
+use crate::{BootLoaderNameTag, CommandLineTag, ElfSectionsTag, FramebufferTag, ModuleTag};
 
 use alloc::boxed::Box;
 use alloc::vec::Vec;
@@ -13,6 +13,7 @@ pub struct Multiboot2InformationBuilder {
     boot_loader_name_tag: Option<Box<BootLoaderNameTag>>,
     command_line_tag: Option<Box<CommandLineTag>>,
     elf_sections_tag: Option<Box<ElfSectionsTag>>,
+    framebuffer_tag: Option<Box<FramebufferTag>>,
     module_tags: Vec<Box<ModuleTag>>,
 }
 
@@ -22,6 +23,7 @@ impl Multiboot2InformationBuilder {
             boot_loader_name_tag: None,
             command_line_tag: None,
             elf_sections_tag: None,
+            framebuffer_tag: None,
             module_tags: Vec::new(),
         }
     }
@@ -36,6 +38,10 @@ impl Multiboot2InformationBuilder {
 
     pub fn elf_sections_tag(&mut self, elf_sections_tag: Box<ElfSectionsTag>) {
         self.elf_sections_tag = Some(elf_sections_tag);
+    }
+
+    pub fn framebuffer_tag(&mut self, framebuffer_tag: Box<FramebufferTag>) {
+        self.framebuffer_tag = Some(framebuffer_tag);
     }
 
     pub fn add_module_tag(&mut self, module_tag: Box<ModuleTag>) {

--- a/multiboot2/src/builder/information.rs
+++ b/multiboot2/src/builder/information.rs
@@ -1,6 +1,9 @@
 //! Exports item [`Multiboot2InformationBuilder`].
 use crate::builder::traits::StructAsBytes;
-use crate::{BootLoaderNameTag, CommandLineTag, ElfSectionsTag, FramebufferTag, ModuleTag};
+use crate::{
+    BasicMemoryInfoTag, BootLoaderNameTag, CommandLineTag, ElfSectionsTag, FramebufferTag,
+    ModuleTag,
+};
 
 use alloc::boxed::Box;
 use alloc::vec::Vec;
@@ -10,6 +13,7 @@ use alloc::vec::Vec;
 /// except for the END tag.
 #[derive(Debug)]
 pub struct Multiboot2InformationBuilder {
+    basic_memory_info_tag: Option<BasicMemoryInfoTag>,
     boot_loader_name_tag: Option<Box<BootLoaderNameTag>>,
     command_line_tag: Option<Box<CommandLineTag>>,
     elf_sections_tag: Option<Box<ElfSectionsTag>>,
@@ -20,12 +24,17 @@ pub struct Multiboot2InformationBuilder {
 impl Multiboot2InformationBuilder {
     pub const fn new() -> Self {
         Self {
+            basic_memory_info_tag: None,
             boot_loader_name_tag: None,
             command_line_tag: None,
             elf_sections_tag: None,
             framebuffer_tag: None,
             module_tags: Vec::new(),
         }
+    }
+
+    pub fn basic_memory_info_tag(&mut self, basic_memory_info_tag: BasicMemoryInfoTag) {
+        self.basic_memory_info_tag = Some(basic_memory_info_tag)
     }
 
     pub fn bootloader_name_tag(&mut self, boot_loader_name_tag: Box<BootLoaderNameTag>) {

--- a/multiboot2/src/builder/information.rs
+++ b/multiboot2/src/builder/information.rs
@@ -1,8 +1,8 @@
 //! Exports item [`Multiboot2InformationBuilder`].
 use crate::builder::traits::StructAsBytes;
 use crate::{
-    BasicMemoryInfoTag, BootInformationInner, BootLoaderNameTag, CommandLineTag, EFISdt32,
-    EFISdt64, ElfSectionsTag, EndTag, FramebufferTag, MemoryMapTag, ModuleTag, RsdpV1Tag,
+    BasicMemoryInfoTag, BootInformationInner, BootLoaderNameTag, CommandLineTag, EFIMemoryMapTag,
+    EFISdt32, EFISdt64, ElfSectionsTag, EndTag, FramebufferTag, MemoryMapTag, ModuleTag, RsdpV1Tag,
     RsdpV2Tag, SmbiosTag,
 };
 
@@ -18,6 +18,7 @@ pub struct Multiboot2InformationBuilder {
     basic_memory_info_tag: Option<BasicMemoryInfoTag>,
     boot_loader_name_tag: Option<Box<BootLoaderNameTag>>,
     command_line_tag: Option<Box<CommandLineTag>>,
+    efi_memory_map_tag: Option<Box<EFIMemoryMapTag>>,
     elf_sections_tag: Option<Box<ElfSectionsTag>>,
     framebuffer_tag: Option<Box<FramebufferTag>>,
     memory_map_tag: Option<Box<MemoryMapTag>>,
@@ -37,6 +38,7 @@ impl Multiboot2InformationBuilder {
             command_line_tag: None,
             efisdt32: None,
             efisdt64: None,
+            efi_memory_map_tag: None,
             elf_sections_tag: None,
             framebuffer_tag: None,
             memory_map_tag: None,
@@ -81,6 +83,9 @@ impl Multiboot2InformationBuilder {
             len += Self::size_or_up_aligned(tag.byte_size())
         }
         if let Some(tag) = &self.efisdt64 {
+            len += Self::size_or_up_aligned(tag.byte_size())
+        }
+        if let Some(tag) = &self.efi_memory_map_tag {
             len += Self::size_or_up_aligned(tag.byte_size())
         }
         if let Some(tag) = &self.elf_sections_tag {
@@ -149,6 +154,9 @@ impl Multiboot2InformationBuilder {
         if let Some(tag) = self.efisdt64.as_ref() {
             Self::build_add_bytes(&mut data, &tag.struct_as_bytes(), false)
         }
+        if let Some(tag) = self.efi_memory_map_tag.as_ref() {
+            Self::build_add_bytes(&mut data, &tag.struct_as_bytes(), false)
+        }
         if let Some(tag) = self.elf_sections_tag.as_ref() {
             Self::build_add_bytes(&mut data, &tag.struct_as_bytes(), false)
         }
@@ -194,6 +202,10 @@ impl Multiboot2InformationBuilder {
 
     pub fn efisdt64(&mut self, efisdt64: EFISdt64) {
         self.efisdt64 = Some(efisdt64);
+    }
+
+    pub fn efi_memory_map_tag(&mut self, efi_memory_map_tag: Box<EFIMemoryMapTag>) {
+        self.efi_memory_map_tag = Some(efi_memory_map_tag);
     }
 
     pub fn elf_sections_tag(&mut self, elf_sections_tag: Box<ElfSectionsTag>) {

--- a/multiboot2/src/builder/information.rs
+++ b/multiboot2/src/builder/information.rs
@@ -1,0 +1,16 @@
+//! Exports item [`Multiboot2InformationBuilder`].
+use crate::{builder::traits::StructAsBytes, CommandLineTag};
+
+use alloc::boxed::Box;
+
+/// Builder to construct a valid Multiboot2 information dynamically at runtime.
+/// The tags will appear in the order of their corresponding enumeration,
+/// except for the END tag.
+#[derive(Debug)]
+pub struct Multiboot2InformationBuilder {}
+
+impl Multiboot2InformationBuilder {
+    pub const fn new() -> Self {
+        Self {}
+    }
+}

--- a/multiboot2/src/builder/information.rs
+++ b/multiboot2/src/builder/information.rs
@@ -3,8 +3,8 @@ use crate::builder::traits::StructAsBytes;
 use crate::{
     BasicMemoryInfoTag, BootInformationInner, BootLoaderNameTag, CommandLineTag,
     EFIBootServicesNotExited, EFIImageHandle32, EFIImageHandle64, EFIMemoryMapTag, EFISdt32,
-    EFISdt64, ElfSectionsTag, EndTag, FramebufferTag, MemoryMapTag, ModuleTag, RsdpV1Tag,
-    RsdpV2Tag, SmbiosTag,
+    EFISdt64, ElfSectionsTag, EndTag, FramebufferTag, ImageLoadPhysAddr, MemoryMapTag, ModuleTag,
+    RsdpV1Tag, RsdpV2Tag, SmbiosTag,
 };
 
 use alloc::boxed::Box;
@@ -25,6 +25,7 @@ pub struct Multiboot2InformationBuilder {
     efi_memory_map_tag: Option<Box<EFIMemoryMapTag>>,
     elf_sections_tag: Option<Box<ElfSectionsTag>>,
     framebuffer_tag: Option<Box<FramebufferTag>>,
+    image_load_addr: Option<ImageLoadPhysAddr>,
     memory_map_tag: Option<Box<MemoryMapTag>>,
     module_tags: Vec<Box<ModuleTag>>,
     efisdt32: Option<EFISdt32>,
@@ -48,6 +49,7 @@ impl Multiboot2InformationBuilder {
             efi_memory_map_tag: None,
             elf_sections_tag: None,
             framebuffer_tag: None,
+            image_load_addr: None,
             memory_map_tag: None,
             module_tags: Vec::new(),
             rsdp_v1_tag: None,
@@ -108,6 +110,9 @@ impl Multiboot2InformationBuilder {
             len += Self::size_or_up_aligned(tag.byte_size())
         }
         if let Some(tag) = &self.framebuffer_tag {
+            len += Self::size_or_up_aligned(tag.byte_size())
+        }
+        if let Some(tag) = &self.image_load_addr {
             len += Self::size_or_up_aligned(tag.byte_size())
         }
         if let Some(tag) = &self.memory_map_tag {
@@ -188,6 +193,9 @@ impl Multiboot2InformationBuilder {
         if let Some(tag) = self.framebuffer_tag.as_ref() {
             Self::build_add_bytes(&mut data, &tag.struct_as_bytes(), false)
         }
+        if let Some(tag) = self.image_load_addr.as_ref() {
+            Self::build_add_bytes(&mut data, &tag.struct_as_bytes(), false)
+        }
         if let Some(tag) = self.memory_map_tag.as_ref() {
             Self::build_add_bytes(&mut data, &tag.struct_as_bytes(), false)
         }
@@ -251,6 +259,10 @@ impl Multiboot2InformationBuilder {
 
     pub fn framebuffer_tag(&mut self, framebuffer_tag: Box<FramebufferTag>) {
         self.framebuffer_tag = Some(framebuffer_tag);
+    }
+
+    pub fn image_load_addr(&mut self, image_load_addr: ImageLoadPhysAddr) {
+        self.image_load_addr = Some(image_load_addr);
     }
 
     pub fn memory_map_tag(&mut self, memory_map_tag: Box<MemoryMapTag>) {

--- a/multiboot2/src/builder/information.rs
+++ b/multiboot2/src/builder/information.rs
@@ -1,6 +1,6 @@
 //! Exports item [`Multiboot2InformationBuilder`].
 use crate::builder::traits::StructAsBytes;
-use crate::{CommandLineTag, ElfSectionsTag, ModuleTag};
+use crate::{BootLoaderNameTag, CommandLineTag, ElfSectionsTag, ModuleTag};
 
 use alloc::boxed::Box;
 use alloc::vec::Vec;
@@ -10,6 +10,7 @@ use alloc::vec::Vec;
 /// except for the END tag.
 #[derive(Debug)]
 pub struct Multiboot2InformationBuilder {
+    boot_loader_name_tag: Option<Box<BootLoaderNameTag>>,
     command_line_tag: Option<Box<CommandLineTag>>,
     elf_sections_tag: Option<Box<ElfSectionsTag>>,
     module_tags: Vec<Box<ModuleTag>>,
@@ -18,10 +19,15 @@ pub struct Multiboot2InformationBuilder {
 impl Multiboot2InformationBuilder {
     pub const fn new() -> Self {
         Self {
+            boot_loader_name_tag: None,
             command_line_tag: None,
             elf_sections_tag: None,
             module_tags: Vec::new(),
         }
+    }
+
+    pub fn bootloader_name_tag(&mut self, boot_loader_name_tag: Box<BootLoaderNameTag>) {
+        self.boot_loader_name_tag = Some(boot_loader_name_tag);
     }
 
     pub fn command_line_tag(&mut self, command_line_tag: Box<CommandLineTag>) {

--- a/multiboot2/src/builder/information.rs
+++ b/multiboot2/src/builder/information.rs
@@ -2,15 +2,24 @@
 use crate::{builder::traits::StructAsBytes, CommandLineTag};
 
 use alloc::boxed::Box;
+use alloc::vec::Vec;
 
 /// Builder to construct a valid Multiboot2 information dynamically at runtime.
 /// The tags will appear in the order of their corresponding enumeration,
 /// except for the END tag.
 #[derive(Debug)]
-pub struct Multiboot2InformationBuilder {}
+pub struct Multiboot2InformationBuilder {
+    command_line_tag: Option<Box<CommandLineTag>>,
+}
 
 impl Multiboot2InformationBuilder {
     pub const fn new() -> Self {
-        Self {}
+        Self {
+            command_line_tag: None,
+        }
+    }
+
+    pub fn command_line_tag(&mut self, command_line_tag: Box<CommandLineTag>) {
+        self.command_line_tag = Some(command_line_tag);
     }
 }

--- a/multiboot2/src/builder/information.rs
+++ b/multiboot2/src/builder/information.rs
@@ -1,5 +1,5 @@
 //! Exports item [`Multiboot2InformationBuilder`].
-use crate::{builder::traits::StructAsBytes, CommandLineTag};
+use crate::{builder::traits::StructAsBytes, CommandLineTag, ModuleTag};
 
 use alloc::boxed::Box;
 use alloc::vec::Vec;
@@ -10,16 +10,22 @@ use alloc::vec::Vec;
 #[derive(Debug)]
 pub struct Multiboot2InformationBuilder {
     command_line_tag: Option<Box<CommandLineTag>>,
+    module_tags: Vec<Box<ModuleTag>>,
 }
 
 impl Multiboot2InformationBuilder {
     pub const fn new() -> Self {
         Self {
             command_line_tag: None,
+            module_tags: Vec::new(),
         }
     }
 
     pub fn command_line_tag(&mut self, command_line_tag: Box<CommandLineTag>) {
         self.command_line_tag = Some(command_line_tag);
+    }
+
+    pub fn add_module_tag(&mut self, module_tag: Box<ModuleTag>) {
+        self.module_tags.push(module_tag);
     }
 }

--- a/multiboot2/src/builder/information.rs
+++ b/multiboot2/src/builder/information.rs
@@ -2,7 +2,7 @@
 use crate::builder::traits::StructAsBytes;
 use crate::{
     BasicMemoryInfoTag, BootInformationInner, BootLoaderNameTag, CommandLineTag, EFISdt32,
-    EFISdt64, ElfSectionsTag, EndTag, FramebufferTag, MemoryMapTag, ModuleTag,
+    EFISdt64, ElfSectionsTag, EndTag, FramebufferTag, MemoryMapTag, ModuleTag, SmbiosTag,
 };
 
 use alloc::boxed::Box;
@@ -23,6 +23,7 @@ pub struct Multiboot2InformationBuilder {
     module_tags: Vec<Box<ModuleTag>>,
     efisdt32: Option<EFISdt32>,
     efisdt64: Option<EFISdt64>,
+    smbios_tags: Vec<Box<SmbiosTag>>,
 }
 
 impl Multiboot2InformationBuilder {
@@ -37,6 +38,7 @@ impl Multiboot2InformationBuilder {
             framebuffer_tag: None,
             memory_map_tag: None,
             module_tags: Vec::new(),
+            smbios_tags: Vec::new(),
         }
     }
 
@@ -86,6 +88,9 @@ impl Multiboot2InformationBuilder {
             len += Self::size_or_up_aligned(tag.byte_size())
         }
         for tag in &self.module_tags {
+            len += Self::size_or_up_aligned(tag.byte_size())
+        }
+        for tag in &self.smbios_tags {
             len += Self::size_or_up_aligned(tag.byte_size())
         }
         // only here size_or_up_aligned is not important, because it is the last tag
@@ -145,6 +150,9 @@ impl Multiboot2InformationBuilder {
         for tag in self.module_tags {
             Self::build_add_bytes(&mut data, &tag.struct_as_bytes(), false)
         }
+        for tag in self.smbios_tags {
+            Self::build_add_bytes(&mut data, &tag.struct_as_bytes(), false)
+        }
 
         Self::build_add_bytes(&mut data, &EndTag::default().struct_as_bytes(), true);
 
@@ -185,6 +193,10 @@ impl Multiboot2InformationBuilder {
 
     pub fn add_module_tag(&mut self, module_tag: Box<ModuleTag>) {
         self.module_tags.push(module_tag);
+    }
+
+    pub fn add_smbios_tag(&mut self, smbios_tag: Box<SmbiosTag>) {
+        self.smbios_tags.push(smbios_tag);
     }
 }
 

--- a/multiboot2/src/builder/mod.rs
+++ b/multiboot2/src/builder/mod.rs
@@ -1,0 +1,6 @@
+//! Module for the builder-feature.
+
+mod information;
+pub(self) mod traits;
+
+pub use information::Multiboot2InformationBuilder;

--- a/multiboot2/src/builder/mod.rs
+++ b/multiboot2/src/builder/mod.rs
@@ -1,7 +1,7 @@
 //! Module for the builder-feature.
 
 mod information;
-pub(self) mod traits;
+pub(crate) mod traits;
 
 pub use information::Multiboot2InformationBuilder;
 

--- a/multiboot2/src/builder/mod.rs
+++ b/multiboot2/src/builder/mod.rs
@@ -4,3 +4,41 @@ mod information;
 pub(self) mod traits;
 
 pub use information::Multiboot2InformationBuilder;
+
+use alloc::alloc::alloc;
+use alloc::boxed::Box;
+use core::alloc::Layout;
+use core::mem::size_of;
+
+use crate::{TagTrait, TagTypeId};
+
+/// Create a boxed tag with the given content.
+pub(super) fn boxed_dst_tag<T: TagTrait<Metadata = usize> + ?Sized>(
+    typ: impl Into<TagTypeId>,
+    content: &[u8],
+) -> Box<T> {
+    // based on https://stackoverflow.com/a/64121094/2192464
+    let (layout, size_offset) = Layout::new::<TagTypeId>()
+        .extend(Layout::new::<u32>())
+        .unwrap();
+    let (layout, inner_offset) = layout
+        .extend(Layout::array::<usize>(content.len()).unwrap())
+        .unwrap();
+    let ptr = unsafe { alloc(layout) };
+    assert!(!ptr.is_null());
+    unsafe {
+        // initialize the content as good as we can
+        ptr.cast::<TagTypeId>().write(typ.into());
+        ptr.add(size_offset).cast::<u32>().write(
+            (content.len() + size_of::<TagTypeId>() + size_of::<u32>())
+                .try_into()
+                .unwrap(),
+        );
+        // initialize body
+        let content_ptr = ptr.add(inner_offset);
+        for (idx, val) in content.iter().enumerate() {
+            content_ptr.add(idx).write(*val);
+        }
+        Box::from_raw(ptr_meta::from_raw_parts_mut(ptr as *mut (), content.len()))
+    }
+}

--- a/multiboot2/src/builder/traits.rs
+++ b/multiboot2/src/builder/traits.rs
@@ -1,16 +1,13 @@
 //! Module for the helper trait [`StructAsBytes`].
 
-use core::mem::size_of;
-
 /// Trait for all tags that helps to create a byte array from the tag.
 /// Useful in builders to construct a byte vector that
 /// represents the Multiboot2 information with all its tags.
-pub(crate) trait StructAsBytes: Sized {
-    /// Returns the size in bytes of the struct, as known during compile
-    /// time. This doesn't use read the "size" field of tags.
-    fn byte_size(&self) -> usize {
-        size_of::<Self>()
-    }
+pub(crate) trait StructAsBytes {
+    /// Returns the size in bytes of the struct.
+    /// This can be either the "size" field of tags or the compile-time size
+    /// (if known).
+    fn byte_size(&self) -> usize;
 
     /// Returns a byte pointer to the begin of the struct.
     fn as_ptr(&self) -> *const u8 {

--- a/multiboot2/src/builder/traits.rs
+++ b/multiboot2/src/builder/traits.rs
@@ -1,0 +1,30 @@
+//! Module for the helper trait [`StructAsBytes`].
+
+use core::mem::size_of;
+
+/// Trait for all tags that helps to create a byte array from the tag.
+/// Useful in builders to construct a byte vector that
+/// represents the Multiboot2 information with all its tags.
+pub(crate) trait StructAsBytes: Sized {
+    /// Returns the size in bytes of the struct, as known during compile
+    /// time. This doesn't use read the "size" field of tags.
+    fn byte_size(&self) -> usize {
+        size_of::<Self>()
+    }
+
+    /// Returns a byte pointer to the begin of the struct.
+    fn as_ptr(&self) -> *const u8 {
+        self as *const Self as *const u8
+    }
+
+    /// Returns the structure as a vector of its bytes.
+    /// The length is determined by [`Self::byte_size`].
+    fn struct_as_bytes(&self) -> alloc::vec::Vec<u8> {
+        let ptr = self.as_ptr();
+        let mut vec = alloc::vec::Vec::with_capacity(self.byte_size());
+        for i in 0..self.byte_size() {
+            vec.push(unsafe { *ptr.add(i) })
+        }
+        vec
+    }
+}

--- a/multiboot2/src/efi.rs
+++ b/multiboot2/src/efi.rs
@@ -1,6 +1,12 @@
 //! All MBI tags related to (U)EFI.
 
+use crate::TagType;
 use crate::TagTypeId;
+use core::convert::TryInto;
+use core::mem::size_of;
+
+#[cfg(feature = "builder")]
+use crate::builder::traits::StructAsBytes;
 
 /// EFI system table in 32 bit mode
 #[derive(Clone, Copy, Debug)]
@@ -12,9 +18,25 @@ pub struct EFISdt32 {
 }
 
 impl EFISdt32 {
+    /// Create a new tag to pass the EFI32 System Table pointer.
+    pub fn new(pointer: u32) -> Self {
+        Self {
+            typ: TagType::Efi32.into(),
+            size: size_of::<Self>().try_into().unwrap(),
+            pointer,
+        }
+    }
+
     /// The physical address of a i386 EFI system table.
     pub fn sdt_address(&self) -> usize {
         self.pointer as usize
+    }
+}
+
+#[cfg(feature = "builder")]
+impl StructAsBytes for EFISdt32 {
+    fn byte_size(&self) -> usize {
+        size_of::<Self>()
     }
 }
 
@@ -28,9 +50,25 @@ pub struct EFISdt64 {
 }
 
 impl EFISdt64 {
+    /// Create a new tag to pass the EFI64 System Table pointer.
+    pub fn new(pointer: u64) -> Self {
+        Self {
+            typ: TagType::Efi64.into(),
+            size: size_of::<Self>().try_into().unwrap(),
+            pointer,
+        }
+    }
+
     /// The physical address of a x86_64 EFI system table.
     pub fn sdt_address(&self) -> usize {
         self.pointer as usize
+    }
+}
+
+#[cfg(feature = "builder")]
+impl StructAsBytes for EFISdt64 {
+    fn byte_size(&self) -> usize {
+        size_of::<Self>()
     }
 }
 
@@ -63,5 +101,24 @@ impl EFIImageHandle64 {
     /// Returns the physical address of the EFI image handle.
     pub fn image_handle(&self) -> usize {
         self.pointer as usize
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{EFISdt32, EFISdt64};
+
+    const ADDR: usize = 0xABCDEF;
+
+    #[test]
+    fn test_build_eftsdt32() {
+        let tag = EFISdt32::new(ADDR.try_into().unwrap());
+        assert_eq!(tag.sdt_address(), ADDR);
+    }
+
+    #[test]
+    fn test_build_eftsdt64() {
+        let tag = EFISdt64::new(ADDR.try_into().unwrap());
+        assert_eq!(tag.sdt_address(), ADDR);
     }
 }

--- a/multiboot2/src/efi.rs
+++ b/multiboot2/src/efi.rs
@@ -82,9 +82,25 @@ pub struct EFIImageHandle32 {
 }
 
 impl EFIImageHandle32 {
+    #[cfg(feature = "builder")]
+    pub fn new(pointer: u32) -> Self {
+        Self {
+            typ: TagType::Efi32Ih.into(),
+            size: size_of::<Self>().try_into().unwrap(),
+            pointer,
+        }
+    }
+
     /// Returns the physical address of the EFI image handle.
     pub fn image_handle(&self) -> usize {
         self.pointer as usize
+    }
+}
+
+#[cfg(feature = "builder")]
+impl StructAsBytes for EFIImageHandle32 {
+    fn byte_size(&self) -> usize {
+        size_of::<Self>()
     }
 }
 
@@ -98,15 +114,31 @@ pub struct EFIImageHandle64 {
 }
 
 impl EFIImageHandle64 {
+    #[cfg(feature = "builder")]
+    pub fn new(pointer: u64) -> Self {
+        Self {
+            typ: TagType::Efi64Ih.into(),
+            size: size_of::<Self>().try_into().unwrap(),
+            pointer,
+        }
+    }
+
     /// Returns the physical address of the EFI image handle.
     pub fn image_handle(&self) -> usize {
         self.pointer as usize
     }
 }
 
+#[cfg(feature = "builder")]
+impl StructAsBytes for EFIImageHandle64 {
+    fn byte_size(&self) -> usize {
+        size_of::<Self>()
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{EFISdt32, EFISdt64};
+    use super::{EFIImageHandle32, EFIImageHandle64, EFISdt32, EFISdt64};
 
     const ADDR: usize = 0xABCDEF;
 
@@ -120,5 +152,17 @@ mod tests {
     fn test_build_eftsdt64() {
         let tag = EFISdt64::new(ADDR.try_into().unwrap());
         assert_eq!(tag.sdt_address(), ADDR);
+    }
+
+    #[test]
+    fn test_build_eftih32() {
+        let tag = EFIImageHandle32::new(ADDR.try_into().unwrap());
+        assert_eq!(tag.image_handle(), ADDR);
+    }
+
+    #[test]
+    fn test_build_eftih64() {
+        let tag = EFIImageHandle32::new(ADDR.try_into().unwrap());
+        assert_eq!(tag.image_handle(), ADDR);
     }
 }

--- a/multiboot2/src/elf_sections.rs
+++ b/multiboot2/src/elf_sections.rs
@@ -12,7 +12,7 @@ const METADATA_SIZE: usize = size_of::<TagTypeId>() + 4 * size_of::<u32>();
 /// This tag contains section header table from an ELF kernel.
 ///
 /// The sections iterator is provided via the `sections` method.
-#[derive(Debug, ptr_meta::Pointee)]
+#[derive(ptr_meta::Pointee)]
 #[repr(C, packed)]
 pub struct ElfSectionsTag {
     typ: TagTypeId,
@@ -80,6 +80,19 @@ impl TagTrait for ElfSectionsTag {
 impl StructAsBytes for ElfSectionsTag {
     fn byte_size(&self) -> usize {
         self.size.try_into().unwrap()
+    }
+}
+
+impl Debug for ElfSectionsTag {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ElfSectionsTag")
+            .field("typ", &{ self.typ })
+            .field("size", &{ self.size })
+            .field("number_of_sections", &{ self.number_of_sections })
+            .field("entry_size", &{ self.entry_size })
+            .field("shndx", &{ self.shndx })
+            .field("sections", &self.sections(0))
+            .finish()
     }
 }
 

--- a/multiboot2/src/elf_sections.rs
+++ b/multiboot2/src/elf_sections.rs
@@ -38,20 +38,7 @@ impl ElfSectionsTag {
     }
 
     /// Get an iterator of loaded ELF sections.
-    ///
-    /// # Examples
-    ///
-    /// ```rust,no_run
-    /// # let boot_info = unsafe { multiboot2::load(0xdeadbeef).unwrap() };
-    /// if let Some(elf_tag) = boot_info.elf_sections_tag() {
-    ///     let mut total = 0;
-    ///     for section in elf_tag.sections(0) {
-    ///         println!("Section: {:?}", section);
-    ///         total += 1;
-    ///     }
-    /// }
-    /// ```
-    pub fn sections(&self, offset: usize) -> ElfSectionIter {
+    pub(crate) fn sections(&self, offset: usize) -> ElfSectionIter {
         let string_section_offset = (self.shndx * self.entry_size) as isize;
         let string_section_ptr =
             unsafe { self.first_section().offset(string_section_offset) as *const _ };

--- a/multiboot2/src/elf_sections.rs
+++ b/multiboot2/src/elf_sections.rs
@@ -5,7 +5,7 @@ use core::mem::size_of;
 use core::str::Utf8Error;
 
 #[cfg(feature = "builder")]
-use {crate::builder::boxed_dst_tag, alloc::boxed::Box};
+use {crate::builder::boxed_dst_tag, crate::builder::traits::StructAsBytes, alloc::boxed::Box};
 
 const METADATA_SIZE: usize = size_of::<TagTypeId>() + 4 * size_of::<u32>();
 
@@ -73,6 +73,13 @@ impl TagTrait for ElfSectionsTag {
     fn dst_size(base_tag: &Tag) -> usize {
         assert!(base_tag.size as usize >= METADATA_SIZE);
         base_tag.size as usize - METADATA_SIZE
+    }
+}
+
+#[cfg(feature = "builder")]
+impl StructAsBytes for ElfSectionsTag {
+    fn byte_size(&self) -> usize {
+        self.size.try_into().unwrap()
     }
 }
 

--- a/multiboot2/src/framebuffer.rs
+++ b/multiboot2/src/framebuffer.rs
@@ -1,5 +1,6 @@
 use crate::{Reader, Tag, TagTrait, TagType, TagTypeId};
 
+use core::fmt::Debug;
 use core::mem::size_of;
 use core::slice;
 use derive_more::Display;
@@ -17,7 +18,7 @@ const METADATA_SIZE: usize = size_of::<TagTypeId>()
     + 2 * size_of::<u8>();
 
 /// The VBE Framebuffer information Tag.
-#[derive(Debug, PartialEq, Eq, ptr_meta::Pointee)]
+#[derive(Eq, ptr_meta::Pointee)]
 #[repr(C, packed)]
 pub struct FramebufferTag {
     typ: TagTypeId,
@@ -153,6 +154,35 @@ impl TagTrait for FramebufferTag {
 impl StructAsBytes for FramebufferTag {
     fn byte_size(&self) -> usize {
         self.size.try_into().unwrap()
+    }
+}
+
+impl Debug for FramebufferTag {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("FramebufferTag")
+            .field("typ", &{ self.typ })
+            .field("size", &{ self.size })
+            .field("buffer_type", &self.buffer_type())
+            .field("address", &{ self.address })
+            .field("pitch", &{ self.pitch })
+            .field("width", &{ self.width })
+            .field("height", &{ self.height })
+            .field("bpp", &self.bpp)
+            .finish()
+    }
+}
+
+impl PartialEq for FramebufferTag {
+    fn eq(&self, other: &Self) -> bool {
+        ({ self.typ } == { other.typ }
+            && { self.size } == { other.size }
+            && { self.address } == { other.address }
+            && { self.pitch } == { other.pitch }
+            && { self.width } == { other.width }
+            && { self.height } == { other.height }
+            && { self.bpp } == { other.bpp }
+            && { self.type_no } == { other.type_no }
+            && self.buffer == other.buffer)
     }
 }
 

--- a/multiboot2/src/framebuffer.rs
+++ b/multiboot2/src/framebuffer.rs
@@ -149,6 +149,13 @@ impl TagTrait for FramebufferTag {
     }
 }
 
+#[cfg(feature = "builder")]
+impl StructAsBytes for FramebufferTag {
+    fn byte_size(&self) -> usize {
+        self.size.try_into().unwrap()
+    }
+}
+
 /// Helper struct for [`FramebufferType`].
 #[derive(Debug, PartialEq, Eq)]
 #[repr(u8)]
@@ -226,7 +233,12 @@ pub struct FramebufferField {
     pub size: u8,
 }
 
-impl StructAsBytes for FramebufferField {}
+#[cfg(feature = "builder")]
+impl StructAsBytes for FramebufferField {
+    fn byte_size(&self) -> usize {
+        size_of::<Self>()
+    }
+}
 
 /// A framebuffer color descriptor in the palette.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -250,4 +262,9 @@ pub struct UnknownFramebufferType(u8);
 #[cfg(feature = "unstable")]
 impl core::error::Error for UnknownFramebufferType {}
 
-impl StructAsBytes for FramebufferColor {}
+#[cfg(feature = "builder")]
+impl StructAsBytes for FramebufferColor {
+    fn byte_size(&self) -> usize {
+        size_of::<Self>()
+    }
+}

--- a/multiboot2/src/image_load_addr.rs
+++ b/multiboot2/src/image_load_addr.rs
@@ -1,4 +1,9 @@
-use crate::TagTypeId;
+use core::convert::TryInto;
+use core::mem::size_of;
+
+#[cfg(feature = "builder")]
+use crate::builder::traits::StructAsBytes;
+use crate::tag_type::{TagType, TagTypeId};
 
 /// If the image has relocatable header tag, this tag contains the image's
 /// base physical address.
@@ -11,8 +16,37 @@ pub struct ImageLoadPhysAddr {
 }
 
 impl ImageLoadPhysAddr {
+    #[cfg(feature = "builder")]
+    pub fn new(load_base_addr: u32) -> Self {
+        Self {
+            typ: TagType::LoadBaseAddr.into(),
+            size: size_of::<Self>().try_into().unwrap(),
+            load_base_addr,
+        }
+    }
+
     /// Returns the load base address.
     pub fn load_base_addr(&self) -> u32 {
         self.load_base_addr
+    }
+}
+
+#[cfg(feature = "builder")]
+impl StructAsBytes for ImageLoadPhysAddr {
+    fn byte_size(&self) -> usize {
+        size_of::<Self>()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ImageLoadPhysAddr;
+
+    const ADDR: u32 = 0xABCDEF;
+
+    #[test]
+    fn test_build_load_addr() {
+        let tag = ImageLoadPhysAddr::new(ADDR);
+        assert_eq!(tag.load_base_addr(), ADDR);
     }
 }

--- a/multiboot2/src/lib.rs
+++ b/multiboot2/src/lib.rs
@@ -1527,16 +1527,6 @@ mod tests {
     }
 
     #[test]
-    /// Compile time test for `MemoryMapTag`.
-    fn e820_memory_map_tag_size() {
-        use super::MemoryMapTag;
-        unsafe {
-            // `MemoryMapTag` is 16 bytes without the 1st entry
-            core::mem::transmute::<[u8; 16], MemoryMapTag>([0u8; 16]);
-        }
-    }
-
-    #[test]
     /// Compile time test for `EFIMemoryMapTag`.
     fn efi_memory_map_tag_size() {
         use super::EFIMemoryMapTag;

--- a/multiboot2/src/lib.rs
+++ b/multiboot2/src/lib.rs
@@ -47,6 +47,8 @@ pub use ptr_meta::Pointee;
 
 use crate::framebuffer::UnknownFramebufferType;
 pub use boot_loader_name::BootLoaderNameTag;
+#[cfg(feature = "builder")]
+use builder::traits::StructAsBytes;
 pub use command_line::CommandLineTag;
 pub use efi::{EFIImageHandle32, EFIImageHandle64, EFISdt32, EFISdt64};
 pub use elf_sections::{
@@ -201,6 +203,22 @@ pub struct BootInformation {
 struct BootInformationInner {
     total_size: u32,
     _reserved: u32,
+}
+
+impl BootInformationInner {
+    fn new(total_size: u32) -> Self {
+        Self {
+            total_size,
+            _reserved: 0,
+        }
+    }
+}
+
+#[cfg(feature = "builder")]
+impl StructAsBytes for BootInformationInner {
+    fn byte_size(&self) -> usize {
+        core::mem::size_of::<Self>()
+    }
 }
 
 impl BootInformation {

--- a/multiboot2/src/lib.rs
+++ b/multiboot2/src/lib.rs
@@ -1545,16 +1545,6 @@ mod tests {
     }
 
     #[test]
-    /// Compile time test for `EFIMemoryMapTag`.
-    fn efi_memory_map_tag_size() {
-        use super::EFIMemoryMapTag;
-        unsafe {
-            // `EFIMemoryMapTag` is 16 bytes without the 1st entry
-            core::mem::transmute::<[u8; 16], EFIMemoryMapTag>([0u8; 16]);
-        }
-    }
-
-    #[test]
     #[cfg(feature = "unstable")]
     /// This test succeeds if it compiles.
     fn mbi_load_error_implements_error() {

--- a/multiboot2/src/lib.rs
+++ b/multiboot2/src/lib.rs
@@ -32,6 +32,9 @@
 //! ## MSRV
 //! The MSRV is 1.56.1 stable.
 
+#[cfg(feature = "builder")]
+extern crate alloc;
+
 // this crate can use std in tests only
 #[cfg_attr(test, macro_use)]
 #[cfg(test)]
@@ -80,6 +83,9 @@ mod rsdp;
 mod smbios;
 mod tag_type;
 mod vbe_info;
+
+#[cfg(feature = "builder")]
+pub mod builder;
 
 /// Magic number that a multiboot2-compliant boot loader will store in `eax` register
 /// right before handoff to the payload (the kernel). This value can be used to check,

--- a/multiboot2/src/lib.rs
+++ b/multiboot2/src/lib.rs
@@ -57,8 +57,8 @@ pub use elf_sections::{
 pub use framebuffer::{FramebufferColor, FramebufferField, FramebufferTag, FramebufferType};
 pub use image_load_addr::ImageLoadPhysAddr;
 pub use memory_map::{
-    BasicMemoryInfoTag, EFIMemoryAreaType, EFIMemoryDesc, EFIMemoryMapTag, MemoryArea,
-    MemoryAreaIter, MemoryAreaType, MemoryMapTag,
+    BasicMemoryInfoTag, EFIBootServicesNotExited, EFIMemoryAreaType, EFIMemoryDesc,
+    EFIMemoryMapTag, MemoryArea, MemoryAreaIter, MemoryAreaType, MemoryMapTag,
 };
 pub use module::{ModuleIter, ModuleTag};
 pub use rsdp::{RsdpV1Tag, RsdpV2Tag};

--- a/multiboot2/src/lib.rs
+++ b/multiboot2/src/lib.rs
@@ -262,9 +262,12 @@ impl BootInformation {
 
     /// Search for the VBE framebuffer tag. The result is `Some(Err(e))`, if the
     /// framebuffer type is unknown, while the framebuffer tag is present.
-    pub fn framebuffer_tag(&self) -> Option<Result<FramebufferTag, UnknownFramebufferType>> {
-        self.get_tag::<Tag, _>(TagType::Framebuffer)
-            .map(framebuffer::framebuffer_tag)
+    pub fn framebuffer_tag(&self) -> Option<Result<&FramebufferTag, UnknownFramebufferType>> {
+        self.get_tag::<FramebufferTag, _>(TagType::Framebuffer)
+            .map(|tag| match tag.buffer_type() {
+                Ok(_) => Ok(tag),
+                Err(e) => Err(e),
+            })
     }
 
     /// Search for the EFI 32-bit SDT tag.
@@ -700,31 +703,34 @@ mod tests {
         assert_eq!(addr, bi.start_address());
         assert_eq!(addr + bytes.0.len(), bi.end_address());
         assert_eq!(bytes.0.len(), bi.total_size());
-        use framebuffer::{FramebufferField, FramebufferTag, FramebufferType};
+        use framebuffer::{FramebufferField, FramebufferType};
+        assert!(bi.framebuffer_tag().is_some());
+        let fbi = bi
+            .framebuffer_tag()
+            .expect("Framebuffer info should be available")
+            .expect("Framebuffer info type should be valid");
+        assert_eq!(fbi.address(), 4244635648);
+        assert_eq!(fbi.pitch(), 5120);
+        assert_eq!(fbi.width(), 1280);
+        assert_eq!(fbi.height(), 720);
+        assert_eq!(fbi.bpp(), 32);
         assert_eq!(
-            bi.framebuffer_tag(),
-            Some(Ok(FramebufferTag {
-                address: 4244635648,
-                pitch: 5120,
-                width: 1280,
-                height: 720,
-                bpp: 32,
-                buffer_type: FramebufferType::RGB {
-                    red: FramebufferField {
-                        position: 16,
-                        size: 8
-                    },
-                    green: FramebufferField {
-                        position: 8,
-                        size: 8
-                    },
-                    blue: FramebufferField {
-                        position: 0,
-                        size: 8
-                    }
+            fbi.buffer_type().unwrap(),
+            FramebufferType::RGB {
+                red: FramebufferField {
+                    position: 16,
+                    size: 8
+                },
+                green: FramebufferField {
+                    position: 8,
+                    size: 8
+                },
+                blue: FramebufferField {
+                    position: 0,
+                    size: 8
                 }
-            }))
-        )
+            }
+        );
     }
 
     #[test]
@@ -762,12 +768,12 @@ mod tests {
             .framebuffer_tag()
             .expect("Framebuffer info should be available")
             .expect("Framebuffer info type should be valid");
-        assert_eq!(fbi.address, 4244635648);
-        assert_eq!(fbi.pitch, 5120);
-        assert_eq!(fbi.width, 1280);
-        assert_eq!(fbi.height, 720);
-        assert_eq!(fbi.bpp, 32);
-        match fbi.buffer_type {
+        assert_eq!(fbi.address(), 4244635648);
+        assert_eq!(fbi.pitch(), 5120);
+        assert_eq!(fbi.width(), 1280);
+        assert_eq!(fbi.height(), 720);
+        assert_eq!(fbi.bpp(), 32);
+        match fbi.buffer_type().unwrap() {
             FramebufferType::Indexed { palette } => assert_eq!(
                 palette,
                 [
@@ -794,16 +800,6 @@ mod tests {
                 ]
             ),
             _ => panic!("Expected indexed framebuffer type."),
-        }
-    }
-
-    #[test]
-    /// Compile time test for `FramebufferTag`.
-    fn framebuffer_tag_size() {
-        use crate::FramebufferTag;
-        unsafe {
-            // 24 for the start + 24 for `FramebufferType`.
-            core::mem::transmute::<[u8; 48], FramebufferTag>([0u8; 48]);
         }
     }
 
@@ -1377,12 +1373,12 @@ mod tests {
             .framebuffer_tag()
             .expect("Framebuffer info should be available")
             .expect("Framebuffer info type should be valid");
-        assert_eq!(fbi.address, 753664);
-        assert_eq!(fbi.pitch, 160);
-        assert_eq!(fbi.width, 80);
-        assert_eq!(fbi.height, 25);
-        assert_eq!(fbi.bpp, 16);
-        assert_eq!(fbi.buffer_type, FramebufferType::Text);
+        assert_eq!(fbi.address(), 753664);
+        assert_eq!(fbi.pitch(), 160);
+        assert_eq!(fbi.width(), 80);
+        assert_eq!(fbi.height(), 25);
+        assert_eq!(fbi.bpp(), 16);
+        assert_eq!(fbi.buffer_type(), Ok(FramebufferType::Text));
     }
 
     #[test]

--- a/multiboot2/src/lib.rs
+++ b/multiboot2/src/lib.rs
@@ -249,13 +249,26 @@ impl BootInformation {
         self.get_tag::<BasicMemoryInfoTag, _>(TagType::BasicMeminfo)
     }
 
-    /// Search for the ELF Sections tag.
-    pub fn elf_sections_tag(&self) -> Option<&ElfSectionsTag> {
+    /// Search for the ELF Sections.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// # let boot_info = unsafe { multiboot2::load(0xdeadbeef).unwrap() };
+    /// if let Some(sections) = boot_info.elf_sections() {
+    ///     let mut total = 0;
+    ///     for section in sections {
+    ///         println!("Section: {:?}", section);
+    ///         total += 1;
+    ///     }
+    /// }
+    /// ```
+    pub fn elf_sections(&self) -> Option<ElfSectionIter> {
         let tag = self.get_tag::<ElfSectionsTag, _>(TagType::ElfSections);
-        if let Some(t) = tag {
+        tag.map(|t| {
             assert!((t.entry_size * t.shndx) <= t.size);
-        }
-        tag
+            t.sections(self.offset)
+        })
     }
 
     /// Search for the Memory map tag.
@@ -467,20 +480,14 @@ impl fmt::Debug for BootInformation {
             .field("module_tags", &self.module_tags());
         // usually this is REALLY big (thousands of tags) => skip it here
 
-        let elf_sections_tag_entries_count = self
-            .elf_sections_tag()
-            .map(|x| x.sections(self.offset).count())
-            .unwrap_or(0);
+        let elf_sections_tag_entries_count = self.elf_sections().map(|x| x.count()).unwrap_or(0);
 
         if elf_sections_tag_entries_count > ELF_SECTIONS_LIMIT {
             debug.field("elf_sections_tags (count)", &elf_sections_tag_entries_count);
         } else {
             debug.field(
                 "elf_sections_tags",
-                &self
-                    .elf_sections_tag()
-                    .map(|x| x.sections(self.offset))
-                    .unwrap_or_default(),
+                &self.elf_sections().unwrap_or_default(),
             );
         }
 
@@ -604,7 +611,7 @@ mod tests {
         assert_eq!(addr, bi.start_address());
         assert_eq!(addr + bytes.0.len(), bi.end_address());
         assert_eq!(bytes.0.len(), bi.total_size());
-        assert!(bi.elf_sections_tag().is_none());
+        assert!(bi.elf_sections().is_none());
         assert!(bi.memory_map_tag().is_none());
         assert!(bi.module_tags().next().is_none());
         assert!(bi.boot_loader_name_tag().is_none());
@@ -628,7 +635,7 @@ mod tests {
         assert_eq!(addr, bi.start_address());
         assert_eq!(addr + bytes.0.len(), bi.end_address());
         assert_eq!(bytes.0.len(), bi.total_size());
-        assert!(bi.elf_sections_tag().is_none());
+        assert!(bi.elf_sections().is_none());
         assert!(bi.memory_map_tag().is_none());
         assert!(bi.module_tags().next().is_none());
         assert!(bi.boot_loader_name_tag().is_none());
@@ -652,7 +659,7 @@ mod tests {
         assert_eq!(addr, bi.start_address());
         assert_eq!(addr + bytes.0.len(), bi.end_address());
         assert_eq!(bytes.0.len(), bi.total_size());
-        assert!(bi.elf_sections_tag().is_none());
+        assert!(bi.elf_sections().is_none());
         assert!(bi.memory_map_tag().is_none());
         assert!(bi.module_tags().next().is_none());
         assert!(bi.boot_loader_name_tag().is_none());
@@ -679,7 +686,7 @@ mod tests {
         assert_eq!(addr, bi.start_address());
         assert_eq!(addr + bytes.0.len(), bi.end_address());
         assert_eq!(bytes.0.len(), bi.total_size());
-        assert!(bi.elf_sections_tag().is_none());
+        assert!(bi.elf_sections().is_none());
         assert!(bi.memory_map_tag().is_none());
         assert!(bi.module_tags().next().is_none());
         assert_eq!(
@@ -1278,16 +1285,15 @@ mod tests {
         assert_eq!(addr, bi.start_address());
         assert_eq!(addr + bytes.len(), bi.end_address());
         assert_eq!(bytes.len(), bi.total_size());
-        let es = bi.elf_sections_tag().unwrap();
-        let mut s = es.sections(bi.offset);
-        let s1 = s.next().expect("Should have one more section");
+        let mut es = bi.elf_sections().unwrap();
+        let s1 = es.next().expect("Should have one more section");
         assert_eq!(".rodata", s1.name().expect("Should be valid utf-8"));
         assert_eq!(0xFFFF_8000_0010_0000, s1.start_address());
         assert_eq!(0xFFFF_8000_0010_3000, s1.end_address());
         assert_eq!(0x0000_0000_0000_3000, s1.size());
         assert_eq!(ElfSectionFlags::ALLOCATED, s1.flags());
         assert_eq!(ElfSectionType::ProgramSection, s1.section_type());
-        let s2 = s.next().expect("Should have one more section");
+        let s2 = es.next().expect("Should have one more section");
         assert_eq!(".text", s2.name().expect("Should be valid utf-8"));
         assert_eq!(0xFFFF_8000_0010_3000, s2.start_address());
         assert_eq!(0xFFFF_8000_0010_C000, s2.end_address());
@@ -1297,7 +1303,7 @@ mod tests {
             s2.flags()
         );
         assert_eq!(ElfSectionType::ProgramSection, s2.section_type());
-        let s3 = s.next().expect("Should have one more section");
+        let s3 = es.next().expect("Should have one more section");
         assert_eq!(".data", s3.name().expect("Should be valid utf-8"));
         assert_eq!(0xFFFF_8000_0010_C000, s3.start_address());
         assert_eq!(0xFFFF_8000_0010_E000, s3.end_address());
@@ -1307,7 +1313,7 @@ mod tests {
             s3.flags()
         );
         assert_eq!(ElfSectionType::ProgramSection, s3.section_type());
-        let s4 = s.next().expect("Should have one more section");
+        let s4 = es.next().expect("Should have one more section");
         assert_eq!(".bss", s4.name().expect("Should be valid utf-8"));
         assert_eq!(0xFFFF_8000_0010_E000, s4.start_address());
         assert_eq!(0xFFFF_8000_0011_3000, s4.end_address());
@@ -1317,7 +1323,7 @@ mod tests {
             s4.flags()
         );
         assert_eq!(ElfSectionType::Uninitialized, s4.section_type());
-        let s5 = s.next().expect("Should have one more section");
+        let s5 = es.next().expect("Should have one more section");
         assert_eq!(".data.rel.ro", s5.name().expect("Should be valid utf-8"));
         assert_eq!(0xFFFF_8000_0011_3000, s5.start_address());
         assert_eq!(0xFFFF_8000_0011_3000, s5.end_address());
@@ -1327,28 +1333,28 @@ mod tests {
             s5.flags()
         );
         assert_eq!(ElfSectionType::ProgramSection, s5.section_type());
-        let s6 = s.next().expect("Should have one more section");
+        let s6 = es.next().expect("Should have one more section");
         assert_eq!(".symtab", s6.name().expect("Should be valid utf-8"));
         assert_eq!(0x0000_0000_0011_3000, s6.start_address());
         assert_eq!(0x0000_0000_0011_5BE0, s6.end_address());
         assert_eq!(0x0000_0000_0000_2BE0, s6.size());
         assert_eq!(ElfSectionFlags::empty(), s6.flags());
         assert_eq!(ElfSectionType::LinkerSymbolTable, s6.section_type());
-        let s7 = s.next().expect("Should have one more section");
+        let s7 = es.next().expect("Should have one more section");
         assert_eq!(".strtab", s7.name().expect("Should be valid utf-8"));
         assert_eq!(0x0000_0000_0011_5BE0, s7.start_address());
         assert_eq!(0x0000_0000_0011_9371, s7.end_address());
         assert_eq!(0x0000_0000_0000_3791, s7.size());
         assert_eq!(ElfSectionFlags::empty(), s7.flags());
         assert_eq!(ElfSectionType::StringTable, s7.section_type());
-        let s8 = s.next().expect("Should have one more section");
+        let s8 = es.next().expect("Should have one more section");
         assert_eq!(".shstrtab", s8.name().expect("Should be valid utf-8"));
         assert_eq!(string_addr, s8.start_address());
         assert_eq!(string_addr + string_bytes.len() as u64, s8.end_address());
         assert_eq!(string_bytes.len() as u64, s8.size());
         assert_eq!(ElfSectionFlags::empty(), s8.flags());
         assert_eq!(ElfSectionType::StringTable, s8.section_type());
-        assert!(s.next().is_none());
+        assert!(es.next().is_none());
         let mut mm = bi.memory_map_tag().unwrap().available_memory_areas();
         let mm1 = mm.next().unwrap();
         assert_eq!(0x00000000, mm1.start_address());
@@ -1463,16 +1469,15 @@ mod tests {
         assert_eq!(addr, bi.start_address());
         assert_eq!(addr + bytes.0.len(), bi.end_address());
         assert_eq!(bytes.0.len(), bi.total_size());
-        let es = bi.elf_sections_tag().unwrap();
-        let mut s = es.sections(bi.offset);
-        let s1 = s.next().expect("Should have one more section");
+        let mut es = bi.elf_sections().unwrap();
+        let s1 = es.next().expect("Should have one more section");
         assert_eq!(".shstrtab", s1.name().expect("Should be valid utf-8"));
         assert_eq!(string_addr, s1.start_address());
         assert_eq!(string_addr + string_bytes.0.len() as u64, s1.end_address());
         assert_eq!(string_bytes.0.len() as u64, s1.size());
         assert_eq!(ElfSectionFlags::empty(), s1.flags());
         assert_eq!(ElfSectionType::StringTable, s1.section_type());
-        assert!(s.next().is_none());
+        assert!(es.next().is_none());
     }
 
     #[test]

--- a/multiboot2/src/memory_map.rs
+++ b/multiboot2/src/memory_map.rs
@@ -69,6 +69,13 @@ impl TagTrait for MemoryMapTag {
     }
 }
 
+#[cfg(feature = "builder")]
+impl StructAsBytes for MemoryMapTag {
+    fn byte_size(&self) -> usize {
+        self.size.try_into().unwrap()
+    }
+}
+
 /// A memory area entry descriptor.
 #[derive(Debug, Clone)]
 #[repr(C)]
@@ -111,7 +118,12 @@ impl MemoryArea {
     }
 }
 
-impl StructAsBytes for MemoryArea {}
+#[cfg(feature = "builder")]
+impl StructAsBytes for MemoryArea {
+    fn byte_size(&self) -> usize {
+        mem::size_of::<Self>()
+    }
+}
 
 /// An enum of possible reported region types.
 /// Inside the Multiboot2 spec this is kind of hidden
@@ -200,6 +212,13 @@ impl BasicMemoryInfoTag {
 
     pub fn memory_upper(&self) -> u32 {
         self.memory_upper
+    }
+}
+
+#[cfg(feature = "builder")]
+impl StructAsBytes for BasicMemoryInfoTag {
+    fn byte_size(&self) -> usize {
+        mem::size_of::<Self>()
     }
 }
 

--- a/multiboot2/src/memory_map.rs
+++ b/multiboot2/src/memory_map.rs
@@ -1,6 +1,7 @@
 use crate::{Tag, TagTrait, TagType, TagTypeId};
 
 use core::convert::TryInto;
+use core::fmt::Debug;
 use core::marker::PhantomData;
 use core::mem;
 
@@ -187,7 +188,6 @@ impl<'a> Iterator for MemoryAreaIter<'a> {
 /// (which had a 24-bit address bus) could use, historically.
 /// Nowadays, much bigger chunks of continuous memory are available at higher
 /// addresses, but the Multiboot standard still references those two terms.
-#[derive(Debug)]
 #[repr(C, packed)]
 pub struct BasicMemoryInfoTag {
     typ: TagTypeId,
@@ -219,6 +219,17 @@ impl BasicMemoryInfoTag {
 impl StructAsBytes for BasicMemoryInfoTag {
     fn byte_size(&self) -> usize {
         mem::size_of::<Self>()
+    }
+}
+
+impl Debug for BasicMemoryInfoTag {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("BasicMemoryInfoTag")
+            .field("typ", &{ self.typ })
+            .field("size", &{ self.size })
+            .field("memory_lower", &{ self.memory_lower })
+            .field("memory_upper", &{ self.memory_upper })
+            .finish()
     }
 }
 

--- a/multiboot2/src/memory_map.rs
+++ b/multiboot2/src/memory_map.rs
@@ -1,5 +1,7 @@
-use crate::TagTypeId;
+use crate::tag_type::{TagType, TagTypeId};
+use core::convert::TryInto;
 use core::marker::PhantomData;
+use core::mem;
 
 /// This tag provides an initial host memory map.
 ///
@@ -149,6 +151,15 @@ pub struct BasicMemoryInfoTag {
 }
 
 impl BasicMemoryInfoTag {
+    pub fn new(memory_lower: u32, memory_upper: u32) -> Self {
+        Self {
+            typ: TagType::BasicMeminfo.into(),
+            size: mem::size_of::<BasicMemoryInfoTag>().try_into().unwrap(),
+            memory_lower,
+            memory_upper,
+        }
+    }
+
     pub fn memory_lower(&self) -> u32 {
         self.memory_lower
     }

--- a/multiboot2/src/memory_map.rs
+++ b/multiboot2/src/memory_map.rs
@@ -449,8 +449,32 @@ impl Default for EFIMemoryDesc {
 #[derive(Debug)]
 #[repr(C)]
 pub struct EFIBootServicesNotExited {
-    typ: u32,
+    typ: TagTypeId,
     size: u32,
+}
+
+impl EFIBootServicesNotExited {
+    #[cfg(feature = "builder")]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[cfg(feature = "builder")]
+impl Default for EFIBootServicesNotExited {
+    fn default() -> Self {
+        Self {
+            typ: TagType::EfiBs.into(),
+            size: mem::size_of::<Self>().try_into().unwrap(),
+        }
+    }
+}
+
+#[cfg(feature = "builder")]
+impl StructAsBytes for EFIBootServicesNotExited {
+    fn byte_size(&self) -> usize {
+        mem::size_of::<Self>()
+    }
 }
 
 /// An iterator over ALL EFI memory areas.

--- a/multiboot2/src/module.rs
+++ b/multiboot2/src/module.rs
@@ -159,4 +159,15 @@ mod tests {
         assert_eq!({ tag.typ }, TagType::Module);
         assert_eq!(tag.cmdline().expect("must be valid UTF-8"), MSG);
     }
+
+    /// Test to generate a tag from a given string.
+    #[test]
+    #[cfg(feature = "builder")]
+    fn test_build_str() {
+        use crate::builder::traits::StructAsBytes;
+
+        let tag = ModuleTag::new(0, 0, MSG);
+        let bytes = tag.struct_as_bytes();
+        assert_eq!(bytes, get_bytes());
+    }
 }

--- a/multiboot2/src/module.rs
+++ b/multiboot2/src/module.rs
@@ -5,7 +5,10 @@ use core::mem::size_of;
 use core::str::Utf8Error;
 
 #[cfg(feature = "builder")]
-use {crate::builder::boxed_dst_tag, alloc::boxed::Box, alloc::vec::Vec};
+use {
+    crate::builder::boxed_dst_tag, crate::builder::traits::StructAsBytes, alloc::boxed::Box,
+    alloc::vec::Vec,
+};
 
 const METADATA_SIZE: usize = size_of::<TagTypeId>() + 3 * size_of::<u32>();
 
@@ -67,6 +70,13 @@ impl TagTrait for ModuleTag {
     fn dst_size(base_tag: &Tag) -> usize {
         assert!(base_tag.size as usize >= METADATA_SIZE);
         base_tag.size as usize - METADATA_SIZE
+    }
+}
+
+#[cfg(feature = "builder")]
+impl StructAsBytes for ModuleTag {
+    fn byte_size(&self) -> usize {
+        self.size.try_into().unwrap()
     }
 }
 

--- a/multiboot2/src/tag_type.rs
+++ b/multiboot2/src/tag_type.rs
@@ -5,6 +5,8 @@
 //! - [`TagTypeId`]
 //! - [`TagType`]
 //! - [`Tag`]
+#[cfg(feature = "builder")]
+use crate::builder::traits::StructAsBytes;
 
 use crate::TagTrait;
 use core::fmt::{Debug, Formatter};
@@ -365,6 +367,13 @@ impl Default for EndTag {
             typ: TagType::End.into(),
             size: 8,
         }
+    }
+}
+
+#[cfg(feature = "builder")]
+impl StructAsBytes for EndTag {
+    fn byte_size(&self) -> usize {
+        core::mem::size_of::<Self>()
     }
 }
 


### PR DESCRIPTION
Hey, I'm currently working on adding Multiboot 2 support to a bootloader ([towboot](https://github.com/hhuOS/towboot)) and while using the multiboot2 and multiboot2-header crates, I encountered some pieces that were missing.

I particular:
 * I added more getters to multiboot2-header (mostly inspired by the ones in multiboot2).
 * I added a builder to multiboot2 (inspired by multiboot2-header).
 * I added the SMBIOS tag.
 * I added a function to find a header in a given (file) slice.

This is mostly just boilerplate, but there were two bigger problems I had to work around:

1) The memory map is only really accurate after exiting Boot Services, but then the bootloader can't allocate anymore.

I've solved this by prefilling the memory map tags with empty entries and overwriting them later on. It seems to work, but it's not pretty.

2) Most tags are dynamically sized. The previous implementation had them fixed-size in Rust and let the content dangle behind them. I think this is a bit weird and it doesn't work when you try to allocate new structs.

I made them dynamically sized – which is worse to handle in Rust (you can't put them on the stack anymore).
In addition, since the `ptr_metadata` feature is currently unstable, I used the slice methods instead. (You can probably revert 800567f8974ab430a012eb01918f716f762bf8e9 once it's stable).

I tried to adjust the tests and add some where appropriate. If that's not enough, I'll add more. :)

There's one test that fails for me on stable Rust (rustc 1.68.0 (2c8cc3432 2023-03-06)), though it works on nightly (rustc 1.70.0-nightly (900c35403 2023-03-08)).

I tried to keep the changes small. I think eg. that it would be nicer if `Multiboot2Header::from_addr` returned a `Result`, but I didn't change it