### PR TITLE
Get mutable references to the memory information

### DIFF
--- a/integration-test/bins/multiboot2_payload/src/verify/chainloader.rs
+++ b/integration-test/bins/multiboot2_payload/src/verify/chainloader.rs
@@ -1,7 +1,7 @@
 use crate::verify::{print_memory_map, print_module_info};
-use multiboot2::BootInformation;
+use multiboot2::{BootInformation, BootInformationInner};
 
-pub fn run(mbi: &BootInformation) -> anyhow::Result<()> {
+pub fn run<T: AsRef<BootInformationInner>>(mbi: &BootInformation<T>) -> anyhow::Result<()> {
     basic_sanity_checks(mbi)?;
     print_memory_map(mbi)?;
     print_module_info(mbi)?;
@@ -9,7 +9,7 @@ pub fn run(mbi: &BootInformation) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn basic_sanity_checks(mbi: &BootInformation) -> anyhow::Result<()> {
+fn basic_sanity_checks<T: AsRef<BootInformationInner>>(mbi: &BootInformation<T>) -> anyhow::Result<()> {
     // Some basic sanity checks
     let bootloader_name = mbi
         .boot_loader_name_tag()

--- a/integration-test/bins/multiboot2_payload/src/verify/grub.rs
+++ b/integration-test/bins/multiboot2_payload/src/verify/grub.rs
@@ -1,7 +1,7 @@
 use crate::verify::{print_elf_info, print_memory_map, print_module_info};
-use multiboot2::BootInformation;
+use multiboot2::{BootInformation, BootInformationInner};
 
-pub fn run(mbi: &BootInformation) -> anyhow::Result<()> {
+pub fn run<T: AsRef<BootInformationInner>>(mbi: &BootInformation<T>) -> anyhow::Result<()> {
     basic_sanity_checks(mbi)?;
     print_memory_map(mbi)?;
     print_module_info(mbi)?;
@@ -9,7 +9,7 @@ pub fn run(mbi: &BootInformation) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn basic_sanity_checks(mbi: &BootInformation) -> anyhow::Result<()> {
+fn basic_sanity_checks<T: AsRef<BootInformationInner>>(mbi: &BootInformation<T>) -> anyhow::Result<()> {
     // Some basic sanity checks
     let bootloader_name = mbi
         .boot_loader_name_tag()

--- a/integration-test/bins/multiboot2_payload/src/verify/mod.rs
+++ b/integration-test/bins/multiboot2_payload/src/verify/mod.rs
@@ -3,9 +3,9 @@ mod grub;
 
 use alloc::format;
 use alloc::vec::Vec;
-use multiboot2::BootInformation;
+use multiboot2::{BootInformation, BootInformationInner};
 
-pub fn run(mbi: &BootInformation) -> anyhow::Result<()> {
+pub fn run<T: AsRef<BootInformationInner>>(mbi: &BootInformation<T>) -> anyhow::Result<()> {
     println!("{mbi:#x?}");
     println!();
 
@@ -27,7 +27,7 @@ pub fn run(mbi: &BootInformation) -> anyhow::Result<()> {
     Ok(())
 }
 
-pub(self) fn print_memory_map(mbi: &BootInformation) -> anyhow::Result<()> {
+pub(self) fn print_memory_map<T: AsRef<BootInformationInner>>(mbi: &BootInformation<T>) -> anyhow::Result<()> {
     let memmap = mbi
         .memory_map_tag()
         .ok_or("Should have memory map")
@@ -46,7 +46,7 @@ pub(self) fn print_memory_map(mbi: &BootInformation) -> anyhow::Result<()> {
     Ok(())
 }
 
-pub(self) fn print_elf_info(mbi: &BootInformation) -> anyhow::Result<()> {
+pub(self) fn print_elf_info<T: AsRef<BootInformationInner>>(mbi: &BootInformation<T>) -> anyhow::Result<()> {
     let sections_iter = mbi
         .elf_sections()
         .ok_or("Should have elf sections")
@@ -71,7 +71,7 @@ pub(self) fn print_elf_info(mbi: &BootInformation) -> anyhow::Result<()> {
     Ok(())
 }
 
-pub(self) fn print_module_info(mbi: &BootInformation) -> anyhow::Result<()> {
+pub(self) fn print_module_info<T: AsRef<BootInformationInner>>(mbi: &BootInformation<T>) -> anyhow::Result<()> {
     let modules = mbi.module_tags().collect::<Vec<_>>();
     if modules.len() != 1 {
         Err(anyhow::Error::msg("Should have exactly one boot module"))?

--- a/multiboot2/src/lib.rs
+++ b/multiboot2/src/lib.rs
@@ -527,6 +527,11 @@ impl<T: AsRef<BootInformationInner> + AsMut<BootInformationInner>> BootInformati
         self.get_tag_mut::<BasicMemoryInfoTag, _>(TagType::BasicMeminfo)
     }
 
+    /// Search for the EFI Memory map tag, return a mutable reference.
+    pub fn efi_memory_map_tag_mut(&mut self) -> Option<&mut EFIMemoryMapTag> {
+        self.get_tag_mut::<EFIMemoryMapTag, _>(TagType::EfiMmap)
+    }
+
     fn get_tag_mut<TagT: TagTrait + ?Sized, TagType: Into<TagTypeId>>(
         &mut self,
         typ: TagType,

--- a/multiboot2/src/lib.rs
+++ b/multiboot2/src/lib.rs
@@ -522,6 +522,11 @@ impl<T: AsRef<BootInformationInner> + AsMut<BootInformationInner>> BootInformati
         self.get_tag_mut::<MemoryMapTag, _>(TagType::Mmap)
     }
 
+    /// Search for the basic memory info tag, return a mutable reference.
+    pub fn basic_memory_info_tag_mut(&mut self) -> Option<&mut BasicMemoryInfoTag> {
+        self.get_tag_mut::<BasicMemoryInfoTag, _>(TagType::BasicMeminfo)
+    }
+
     fn get_tag_mut<TagT: TagTrait + ?Sized, TagType: Into<TagTypeId>>(
         &mut self,
         typ: TagType,

--- a/multiboot2/src/memory_map.rs
+++ b/multiboot2/src/memory_map.rs
@@ -61,6 +61,13 @@ impl MemoryMapTag {
         assert_eq!(self.entry_size as usize, mem::size_of::<MemoryArea>());
         &self.areas
     }
+
+    /// Return a mutable slice with all memory areas.
+    pub fn all_memory_areas_mut(&mut self) -> &mut [MemoryArea] {
+        // If this ever fails, we need to model this differently in this crate.
+        assert_eq!(self.entry_size as usize, mem::size_of::<MemoryArea>());
+        &mut self.areas
+    }
 }
 
 impl TagTrait for MemoryMapTag {

--- a/multiboot2/src/tag_trait.rs
+++ b/multiboot2/src/tag_trait.rs
@@ -56,4 +56,17 @@ pub trait TagTrait: Pointee {
         let ptr = ptr_meta::from_raw_parts(ptr.cast(), Self::dst_size(tag));
         &*ptr
     }
+
+    /// Creates a reference to a (dynamically sized) tag type in a safe way.
+    /// DST tags need to implement a proper [`Self::dst_size`] implementation.
+    ///
+    /// # Safety
+    /// Callers must be sure that the "size" field of the provided [`Tag`] is
+    /// sane and the underlying memory valid. The implementation of this trait
+    /// **must have** a correct [`Self::dst_size`] implementation.
+    unsafe fn from_base_tag_mut<'a>(tag: &mut Tag) -> &'a mut Self {
+        let ptr = core::ptr::addr_of_mut!(*tag);
+        let ptr = ptr_meta::from_raw_parts_mut(ptr.cast(), Self::dst_size(tag));
+        &mut *ptr
+    }
 }


### PR DESCRIPTION
This is (hopefully) the last part I split off of #133.

This PR adds the functions `basic_memory_info_tag_mut`, `memory_map_tag_mut` adn `efi_memory_map_tag_mut`. The memory map tags each get their own `memory_areas_mut`.



This may sound wrong at first and yes, this is really hacky, but I'm afraid that I need this.

The correct way to pass memory information from the bootloader to the kernel would be

1. gather memory information
2. build the appropriate tags
3. pass them into the builder
4. build the information struct

*But* steps 2 and 4 allocate memory which in turn might invalidate the gathered memory map.
One could either risk this and just pass possibly outdated information – or do it the other way round:

1. approximate how much memory areas there are
2. build the whole information struct
3. get the correct memory information
4. get the appropriate tags, mutably
5. put the information in there

(The downside to this approach is that there may be empty areas at the end (which seems to be fine) or that there are not enough areas.)