### PR TITLE
streamline default derives

### DIFF
--- a/multiboot2-header/src/address.rs
+++ b/multiboot2-header/src/address.rs
@@ -6,7 +6,7 @@ use core::mem::size_of;
 /// other format. Required for legacy boot (BIOS).
 /// Determines load addresses.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[repr(C, align(8))]
+#[repr(C)]
 pub struct AddressHeaderTag {
     typ: HeaderTagType,
     flags: HeaderTagFlag,

--- a/multiboot2-header/src/address.rs
+++ b/multiboot2-header/src/address.rs
@@ -5,8 +5,8 @@ use core::mem::size_of;
 /// format, but it must be provided if the image is in a.out format or in some
 /// other format. Required for legacy boot (BIOS).
 /// Determines load addresses.
-#[derive(Copy, Clone, Debug)]
-#[repr(C)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[repr(C, align(8))]
 pub struct AddressHeaderTag {
     typ: HeaderTagType,
     flags: HeaderTagFlag,

--- a/multiboot2-header/src/builder/header.rs
+++ b/multiboot2-header/src/builder/header.rs
@@ -14,7 +14,7 @@ use core::mem::size_of;
 /// Builder to construct a valid Multiboot2 header dynamically at runtime.
 /// The tags will appear in the order of their corresponding enumeration,
 /// except for the END tag.
-#[derive(Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Multiboot2HeaderBuilder {
     arch: HeaderTagISA,
     // first

--- a/multiboot2-header/src/builder/information_request.rs
+++ b/multiboot2-header/src/builder/information_request.rs
@@ -11,7 +11,7 @@ use multiboot2::TagTypeId;
 /// at runtime. The information request tag has a dedicated builder because this way one
 /// can dynamically attach several requests to it. Otherwise, the number of requested tags
 /// must be known at compile time.
-#[derive(Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg(feature = "builder")]
 pub struct InformationRequestHeaderTagBuilder {
     flag: HeaderTagFlag,

--- a/multiboot2-header/src/console.rs
+++ b/multiboot2-header/src/console.rs
@@ -3,7 +3,7 @@ use core::mem::size_of;
 
 /// Possible flags for [`ConsoleHeaderTag`].
 #[repr(u32)]
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum ConsoleHeaderTagFlags {
     /// Console required.
     ConsoleRequired = 0,
@@ -13,7 +13,7 @@ pub enum ConsoleHeaderTagFlags {
 
 /// Tells that a console must be available in MBI.
 /// Only relevant for legacy BIOS.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[repr(C)]
 pub struct ConsoleHeaderTag {
     typ: HeaderTagType,

--- a/multiboot2-header/src/end.rs
+++ b/multiboot2-header/src/end.rs
@@ -2,8 +2,8 @@ use crate::{HeaderTagFlag, HeaderTagType};
 use core::mem::size_of;
 
 /// Terminates a list of optional tags in a Multiboot2 header.
-#[derive(Copy, Clone, Debug)]
-#[repr(C)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[repr(C, align(8))]
 pub struct EndHeaderTag {
     // u16 value
     typ: HeaderTagType,

--- a/multiboot2-header/src/end.rs
+++ b/multiboot2-header/src/end.rs
@@ -3,7 +3,7 @@ use core::mem::size_of;
 
 /// Terminates a list of optional tags in a Multiboot2 header.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[repr(C, align(8))]
+#[repr(C)]
 pub struct EndHeaderTag {
     // u16 value
     typ: HeaderTagType,

--- a/multiboot2-header/src/entry_address.rs
+++ b/multiboot2-header/src/entry_address.rs
@@ -5,7 +5,7 @@ use core::mem::size_of;
 
 /// Specifies the physical address to which the boot loader should jump in
 /// order to start running the operating system. Not needed for ELF files.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 #[repr(C)]
 pub struct EntryAddressHeaderTag {
     typ: HeaderTagType,

--- a/multiboot2-header/src/entry_efi_32.rs
+++ b/multiboot2-header/src/entry_efi_32.rs
@@ -9,7 +9,7 @@ use core::mem::size_of;
 ///
 /// Technically, this is equivalent to the [`crate::EntryAddressHeaderTag`] but with a different
 /// [`crate::HeaderTagType`].
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 #[repr(C)]
 pub struct EntryEfi32HeaderTag {
     typ: HeaderTagType,

--- a/multiboot2-header/src/entry_efi_64.rs
+++ b/multiboot2-header/src/entry_efi_64.rs
@@ -9,7 +9,7 @@ use core::mem::size_of;
 ///
 /// Technically, this is equivalent to the [`crate::EntryAddressHeaderTag`] but with a different
 /// [`crate::HeaderTagType`].
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 #[repr(C)]
 pub struct EntryEfi64HeaderTag {
     typ: HeaderTagType,

--- a/multiboot2-header/src/framebuffer.rs
+++ b/multiboot2-header/src/framebuffer.rs
@@ -5,7 +5,7 @@ use core::mem::size_of;
 /// is present the bootloader assumes that the payload
 /// has framebuffer support. Note: This is only a
 /// recommended mode. Only relevant on legacy BIOS.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[repr(C)]
 pub struct FramebufferHeaderTag {
     typ: HeaderTagType,

--- a/multiboot2-header/src/header.rs
+++ b/multiboot2-header/src/header.rs
@@ -227,7 +227,7 @@ impl core::error::Error for LoadError {}
 /// The "basic" Multiboot2 header. This means only the properties, that are known during
 /// compile time. All other information are derived during runtime from the size property.
 #[derive(Copy, Clone, PartialEq, Eq)]
-#[repr(C, align(8))]
+#[repr(C)]
 pub struct Multiboot2BasicHeader {
     /// Must be the value of [`MULTIBOOT2_HEADER_MAGIC`].
     header_magic: u32,

--- a/multiboot2-header/src/header.rs
+++ b/multiboot2-header/src/header.rs
@@ -200,7 +200,7 @@ impl<'a> Debug for Multiboot2Header<'a> {
 
 /// Errors that can occur when parsing a header from a slice.
 /// See [`Multiboot2Header::find_header`].
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum LoadError {
     /// The checksum does not match the data.
     ChecksumMismatch,
@@ -226,8 +226,8 @@ impl core::error::Error for LoadError {}
 ///
 /// The "basic" Multiboot2 header. This means only the properties, that are known during
 /// compile time. All other information are derived during runtime from the size property.
-#[derive(Copy, Clone)]
-#[repr(C)]
+#[derive(Copy, Clone, PartialEq, Eq)]
+#[repr(C, align(8))]
 pub struct Multiboot2BasicHeader {
     /// Must be the value of [`MULTIBOOT2_HEADER_MAGIC`].
     header_magic: u32,

--- a/multiboot2-header/src/information_request.rs
+++ b/multiboot2-header/src/information_request.rs
@@ -8,7 +8,7 @@ use multiboot2::TagType;
 
 /// Specifies what specific tag types the bootloader should provide
 /// inside the mbi.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 #[repr(C)]
 pub struct InformationRequestHeaderTag<const N: usize> {
     typ: HeaderTagType,
@@ -126,7 +126,7 @@ impl<'a> Iterator for InformationRequestHeaderTagIter<'a> {
 impl<'a> Debug for InformationRequestHeaderTagIter<'a> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let mut debug = f.debug_list();
-        (*self).for_each(|e| {
+        self.for_each(|e| {
             debug.entry(&e);
         });
         debug.finish()

--- a/multiboot2-header/src/module_align.rs
+++ b/multiboot2-header/src/module_align.rs
@@ -3,7 +3,7 @@ use core::mem::size_of;
 
 /// If this tag is present, provided boot modules must be page aligned.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[repr(C, align(8))]
+#[repr(C)]
 pub struct ModuleAlignHeaderTag {
     typ: HeaderTagType,
     flags: HeaderTagFlag,

--- a/multiboot2-header/src/module_align.rs
+++ b/multiboot2-header/src/module_align.rs
@@ -2,8 +2,8 @@ use crate::{HeaderTagFlag, HeaderTagType};
 use core::mem::size_of;
 
 /// If this tag is present, provided boot modules must be page aligned.
-#[derive(Copy, Clone, Debug)]
-#[repr(C)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[repr(C, align(8))]
 pub struct ModuleAlignHeaderTag {
     typ: HeaderTagType,
     flags: HeaderTagFlag,

--- a/multiboot2-header/src/relocatable.rs
+++ b/multiboot2-header/src/relocatable.rs
@@ -8,7 +8,7 @@ use core::mem::size_of;
 /// but not lower than min addr and ‘2’ means load image at highest possible
 /// address but not higher than max addr.
 #[repr(u32)]
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum RelocatableHeaderTagPreference {
     /// Let boot loader decide.
     None = 0,
@@ -19,8 +19,8 @@ pub enum RelocatableHeaderTagPreference {
 }
 
 /// This tag indicates that the image is relocatable.
-#[derive(Copy, Clone)]
-#[repr(C)]
+#[derive(Copy, Clone, PartialEq, Eq)]
+#[repr(C, align(8))]
 pub struct RelocatableHeaderTag {
     typ: HeaderTagType,
     flags: HeaderTagFlag,

--- a/multiboot2-header/src/relocatable.rs
+++ b/multiboot2-header/src/relocatable.rs
@@ -20,7 +20,7 @@ pub enum RelocatableHeaderTagPreference {
 
 /// This tag indicates that the image is relocatable.
 #[derive(Copy, Clone, PartialEq, Eq)]
-#[repr(C, align(8))]
+#[repr(C)]
 pub struct RelocatableHeaderTag {
     typ: HeaderTagType,
     flags: HeaderTagFlag,

--- a/multiboot2-header/src/tags.rs
+++ b/multiboot2-header/src/tags.rs
@@ -4,7 +4,7 @@
 
 /// ISA/ARCH in Multiboot2 header.
 #[repr(u32)]
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum HeaderTagISA {
     /// Spec: "means 32-bit (protected) mode of i386".
     /// Caution: This is confusing. If you use the EFI64-tag
@@ -19,7 +19,7 @@ pub enum HeaderTagISA {
 /// from the example C code at the bottom of the Multiboot2 specification. This value
 /// stands in the `typ` property of [`crate::tags::HeaderTag`].
 #[repr(u16)]
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum HeaderTagType {
     /// Type for [`crate::EndHeaderTag`].
     End = 0,
@@ -54,7 +54,7 @@ impl HeaderTagType {
 
 /// Flags for Multiboot2 header tags.
 #[repr(u16)]
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum HeaderTagFlag {
     Required = 0,
     Optional = 1,
@@ -63,8 +63,8 @@ pub enum HeaderTagFlag {
 /// Common properties for all header tags. Other tags may have additional fields
 /// that depend on the `typ` and the `size` field. All tags share the same beginning of the
 /// struct.
-#[derive(Copy, Clone, Debug)]
-#[repr(C)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[repr(C, align(8))]
 pub struct HeaderTag {
     // u16 value
     typ: HeaderTagType,

--- a/multiboot2-header/src/tags.rs
+++ b/multiboot2-header/src/tags.rs
@@ -64,7 +64,7 @@ pub enum HeaderTagFlag {
 /// that depend on the `typ` and the `size` field. All tags share the same beginning of the
 /// struct.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[repr(C, align(8))]
+#[repr(C)]
 pub struct HeaderTag {
     // u16 value
     typ: HeaderTagType,

--- a/multiboot2-header/src/uefi_bs.rs
+++ b/multiboot2-header/src/uefi_bs.rs
@@ -3,8 +3,8 @@ use core::mem::size_of;
 
 /// This tag indicates that payload supports starting without terminating UEFI boot services.
 /// Or in other words: The payload wants to use UEFI boot services.
-#[derive(Copy, Clone, Debug)]
-#[repr(C)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[repr(C, align(8))]
 pub struct EfiBootServiceHeaderTag {
     typ: HeaderTagType,
     flags: HeaderTagFlag,

--- a/multiboot2-header/src/uefi_bs.rs
+++ b/multiboot2-header/src/uefi_bs.rs
@@ -4,7 +4,7 @@ use core::mem::size_of;
 /// This tag indicates that payload supports starting without terminating UEFI boot services.
 /// Or in other words: The payload wants to use UEFI boot services.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[repr(C, align(8))]
+#[repr(C)]
 pub struct EfiBootServiceHeaderTag {
     typ: HeaderTagType,
     flags: HeaderTagFlag,

--- a/multiboot2/src/boot_loader_name.rs
+++ b/multiboot2/src/boot_loader_name.rs
@@ -13,7 +13,8 @@ const METADATA_SIZE: usize = size_of::<TagTypeId>() + size_of::<u32>();
 
 /// The bootloader name tag.
 #[derive(ptr_meta::Pointee)]
-#[repr(C, packed)] // only repr(C) would add unwanted padding before first_section
+#[derive(PartialEq, Eq)]
+#[repr(C, align(8))]
 pub struct BootLoaderNameTag {
     typ: TagTypeId,
     size: u32,

--- a/multiboot2/src/boot_loader_name.rs
+++ b/multiboot2/src/boot_loader_name.rs
@@ -12,9 +12,8 @@ use {
 const METADATA_SIZE: usize = size_of::<TagTypeId>() + size_of::<u32>();
 
 /// The bootloader name tag.
-#[derive(ptr_meta::Pointee)]
-#[derive(PartialEq, Eq)]
-#[repr(C, align(8))]
+#[derive(ptr_meta::Pointee, PartialEq, Eq)]
+#[repr(C)]
 pub struct BootLoaderNameTag {
     typ: TagTypeId,
     size: u32,

--- a/multiboot2/src/builder/information.rs
+++ b/multiboot2/src/builder/information.rs
@@ -15,6 +15,7 @@ use core::mem::size_of;
 /// The tags will appear in the order of their corresponding enumeration,
 /// except for the END tag.
 #[derive(Debug)]
+// #[derive(Debug, PartialEq, Eq)] // wait for uefi-raw 0.3.0
 pub struct Multiboot2InformationBuilder {
     basic_memory_info_tag: Option<BasicMemoryInfoTag>,
     boot_loader_name_tag: Option<Box<BootLoaderNameTag>>,

--- a/multiboot2/src/command_line.rs
+++ b/multiboot2/src/command_line.rs
@@ -18,9 +18,8 @@ pub(crate) const METADATA_SIZE: usize = mem::size_of::<TagTypeId>() + mem::size_
 ///
 /// The string is a normal C-style UTF-8 zero-terminated string that can be
 /// obtained via the `command_line` method.
-#[derive(ptr_meta::Pointee)]
-#[derive(PartialEq, Eq)]
-#[repr(C, align(8))]
+#[derive(ptr_meta::Pointee, PartialEq, Eq)]
+#[repr(C)]
 pub struct CommandLineTag {
     typ: TagTypeId,
     size: u32,

--- a/multiboot2/src/command_line.rs
+++ b/multiboot2/src/command_line.rs
@@ -18,8 +18,9 @@ pub(crate) const METADATA_SIZE: usize = mem::size_of::<TagTypeId>() + mem::size_
 ///
 /// The string is a normal C-style UTF-8 zero-terminated string that can be
 /// obtained via the `command_line` method.
-#[repr(C, packed)] // only repr(C) would add unwanted padding before first_section
 #[derive(ptr_meta::Pointee)]
+#[derive(PartialEq, Eq)]
+#[repr(C, align(8))]
 pub struct CommandLineTag {
     typ: TagTypeId,
     size: u32,

--- a/multiboot2/src/efi.rs
+++ b/multiboot2/src/efi.rs
@@ -9,8 +9,8 @@ use core::mem::size_of;
 use crate::builder::traits::StructAsBytes;
 
 /// EFI system table in 32 bit mode
-#[derive(Clone, Copy, Debug)]
-#[repr(C, packed)] // only repr(C) would add unwanted padding before first_section
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[repr(C, align(8))]
 pub struct EFISdt32 {
     typ: TagTypeId,
     size: u32,
@@ -41,8 +41,8 @@ impl StructAsBytes for EFISdt32 {
 }
 
 /// EFI system table in 64 bit mode
-#[derive(Clone, Copy, Debug)]
-#[repr(C)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[repr(C, align(8))]
 pub struct EFISdt64 {
     typ: TagTypeId,
     size: u32,
@@ -73,8 +73,8 @@ impl StructAsBytes for EFISdt64 {
 }
 
 /// Contains pointer to boot loader image handle.
-#[derive(Debug)]
-#[repr(C)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[repr(C, align(8))]
 pub struct EFIImageHandle32 {
     typ: TagTypeId,
     size: u32,
@@ -105,8 +105,8 @@ impl StructAsBytes for EFIImageHandle32 {
 }
 
 /// Contains pointer to boot loader image handle.
-#[derive(Debug)]
-#[repr(C)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[repr(C, align(8))]
 pub struct EFIImageHandle64 {
     typ: TagTypeId,
     size: u32,

--- a/multiboot2/src/efi.rs
+++ b/multiboot2/src/efi.rs
@@ -10,7 +10,7 @@ use crate::builder::traits::StructAsBytes;
 
 /// EFI system table in 32 bit mode
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[repr(C, align(8))]
+#[repr(C)]
 pub struct EFISdt32 {
     typ: TagTypeId,
     size: u32,
@@ -42,7 +42,7 @@ impl StructAsBytes for EFISdt32 {
 
 /// EFI system table in 64 bit mode
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[repr(C, align(8))]
+#[repr(C)]
 pub struct EFISdt64 {
     typ: TagTypeId,
     size: u32,
@@ -74,7 +74,7 @@ impl StructAsBytes for EFISdt64 {
 
 /// Contains pointer to boot loader image handle.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[repr(C, align(8))]
+#[repr(C)]
 pub struct EFIImageHandle32 {
     typ: TagTypeId,
     size: u32,
@@ -106,7 +106,7 @@ impl StructAsBytes for EFIImageHandle32 {
 
 /// Contains pointer to boot loader image handle.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[repr(C, align(8))]
+#[repr(C)]
 pub struct EFIImageHandle64 {
     typ: TagTypeId,
     size: u32,

--- a/multiboot2/src/elf_sections.rs
+++ b/multiboot2/src/elf_sections.rs
@@ -16,7 +16,8 @@ const METADATA_SIZE: usize = size_of::<TagTypeId>() + 4 * size_of::<u32>();
 ///
 /// The sections iterator is provided via the `sections` method.
 #[derive(ptr_meta::Pointee)]
-#[repr(C, packed)]
+#[derive(PartialEq, Eq)]
+#[repr(C, align(8))]
 pub struct ElfSectionsTag {
     typ: TagTypeId,
     pub(crate) size: u32,
@@ -142,7 +143,7 @@ impl Default for ElfSectionIter {
 }
 
 /// A single generic ELF Section.
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct ElfSection {
     inner: *const u8,
     string_section: *const u8,
@@ -353,7 +354,7 @@ impl ElfSectionInner for ElfSectionInner64 {
 }
 
 /// An enum abstraction over raw ELF section types.
-#[derive(PartialEq, Eq, Debug, Copy, Clone)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(u32)]
 pub enum ElfSectionType {
     /// This value marks the section header as inactive; it does not have an

--- a/multiboot2/src/elf_sections.rs
+++ b/multiboot2/src/elf_sections.rs
@@ -15,9 +15,8 @@ const METADATA_SIZE: usize = size_of::<TagTypeId>() + 4 * size_of::<u32>();
 /// This tag contains section header table from an ELF kernel.
 ///
 /// The sections iterator is provided via the `sections` method.
-#[derive(ptr_meta::Pointee)]
-#[derive(PartialEq, Eq)]
-#[repr(C, align(8))]
+#[derive(ptr_meta::Pointee, PartialEq, Eq)]
+#[repr(C)]
 pub struct ElfSectionsTag {
     typ: TagTypeId,
     pub(crate) size: u32,

--- a/multiboot2/src/framebuffer.rs
+++ b/multiboot2/src/framebuffer.rs
@@ -51,9 +51,8 @@ const METADATA_SIZE: usize = size_of::<TagTypeId>()
     + 2 * size_of::<u8>();
 
 /// The VBE Framebuffer information Tag.
-#[derive(ptr_meta::Pointee)]
-#[derive(Eq)]
-#[repr(C, align(8))]
+#[derive(ptr_meta::Pointee, Eq)]
+#[repr(C)]
 pub struct FramebufferTag {
     typ: TagTypeId,
     size: u32,

--- a/multiboot2/src/framebuffer.rs
+++ b/multiboot2/src/framebuffer.rs
@@ -51,8 +51,9 @@ const METADATA_SIZE: usize = size_of::<TagTypeId>()
     + 2 * size_of::<u8>();
 
 /// The VBE Framebuffer information Tag.
-#[derive(Eq, ptr_meta::Pointee)]
-#[repr(C, packed)]
+#[derive(ptr_meta::Pointee)]
+#[derive(Eq)]
+#[repr(C, align(8))]
 pub struct FramebufferTag {
     typ: TagTypeId,
     size: u32,
@@ -244,7 +245,7 @@ impl TryFrom<u8> for FramebufferTypeId {
 }
 
 /// The type of framebuffer.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum FramebufferType<'a> {
     /// Indexed color.
     Indexed {
@@ -300,7 +301,7 @@ impl<'a> FramebufferType<'a> {
 }
 
 /// An RGB color type field.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FramebufferField {
     /// Color field position.
     pub position: u8,
@@ -317,8 +318,8 @@ impl StructAsBytes for FramebufferField {
 }
 
 /// A framebuffer color descriptor in the palette.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[repr(C, packed)] // only repr(C) would add unwanted padding at the end
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(C)] // no align(8) here is correct
 pub struct FramebufferColor {
     /// The Red component of the color.
     pub red: u8,
@@ -342,5 +343,16 @@ impl core::error::Error for UnknownFramebufferType {}
 impl StructAsBytes for FramebufferColor {
     fn byte_size(&self) -> usize {
         size_of::<Self>()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Compile time test
+    #[test]
+    fn test_size() {
+        assert_eq!(size_of::<FramebufferColor>(), 3)
     }
 }

--- a/multiboot2/src/image_load_addr.rs
+++ b/multiboot2/src/image_load_addr.rs
@@ -8,7 +8,7 @@ use {
 /// If the image has relocatable header tag, this tag contains the image's
 /// base physical address.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[repr(C, align(8))]
+#[repr(C)]
 pub struct ImageLoadPhysAddr {
     typ: TagTypeId,
     size: u32,

--- a/multiboot2/src/image_load_addr.rs
+++ b/multiboot2/src/image_load_addr.rs
@@ -7,8 +7,8 @@ use {
 
 /// If the image has relocatable header tag, this tag contains the image's
 /// base physical address.
-#[derive(Debug)]
-#[repr(C)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[repr(C, align(8))]
 pub struct ImageLoadPhysAddr {
     typ: TagTypeId,
     size: u32,

--- a/multiboot2/src/lib.rs
+++ b/multiboot2/src/lib.rs
@@ -173,7 +173,8 @@ pub unsafe fn load_with_offset(
 
 /// Error type that describes errors while loading/parsing a multiboot2 information structure
 /// from a given address.
-#[derive(Debug, Display)]
+#[derive(Display)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum MbiLoadError {
     /// The address is invalid. Make sure that the address is 8-byte aligned,
     /// according to the spec.

--- a/multiboot2/src/lib.rs
+++ b/multiboot2/src/lib.rs
@@ -173,8 +173,7 @@ pub unsafe fn load_with_offset(
 
 /// Error type that describes errors while loading/parsing a multiboot2 information structure
 /// from a given address.
-#[derive(Display)]
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Display, Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum MbiLoadError {
     /// The address is invalid. Make sure that the address is 8-byte aligned,
     /// according to the spec.
@@ -386,7 +385,7 @@ impl BootInformation {
     /// use std::str::Utf8Error;
     /// use multiboot2::{Tag, TagTrait, TagTypeId};
     ///
-    /// #[repr(C, align(8))]
+    /// #[repr(C)]
     /// #[derive(multiboot2::Pointee)] // Only needed for DSTs.
     /// struct CustomTag {
     ///     // new type from the lib: has repr(u32)

--- a/multiboot2/src/memory_map.rs
+++ b/multiboot2/src/memory_map.rs
@@ -22,8 +22,9 @@ const METADATA_SIZE: usize = mem::size_of::<TagTypeId>() + 3 * mem::size_of::<u3
 /// This tag may not be provided by some boot loaders on EFI platforms if EFI
 /// boot services are enabled and available for the loaded image (The EFI boot
 /// services tag may exist in the Multiboot2 boot information structure).
-#[derive(Debug, ptr_meta::Pointee)]
-#[repr(C)]
+#[derive( ptr_meta::Pointee)]
+#[derive(Debug, PartialEq, Eq)]
+#[repr(C, align(8))]
 pub struct MemoryMapTag {
     typ: TagTypeId,
     size: u32,
@@ -80,8 +81,8 @@ impl StructAsBytes for MemoryMapTag {
 }
 
 /// A memory area entry descriptor.
-#[derive(Debug, Clone)]
-#[repr(C)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[repr(C, align(8))]
 pub struct MemoryArea {
     base_addr: u64,
     length: u64,
@@ -131,7 +132,7 @@ impl StructAsBytes for MemoryArea {
 /// An enum of possible reported region types.
 /// Inside the Multiboot2 spec this is kind of hidden
 /// inside the implementation of `struct multiboot_mmap_entry`.
-#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(u32)]
 pub enum MemoryAreaType {
     /// Available memory free to be used by the OS.
@@ -190,7 +191,8 @@ impl<'a> Iterator for MemoryAreaIter<'a> {
 /// (which had a 24-bit address bus) could use, historically.
 /// Nowadays, much bigger chunks of continuous memory are available at higher
 /// addresses, but the Multiboot standard still references those two terms.
-#[repr(C, packed)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[repr(C, align(8))]
 pub struct BasicMemoryInfoTag {
     typ: TagTypeId,
     size: u32,
@@ -224,22 +226,13 @@ impl StructAsBytes for BasicMemoryInfoTag {
     }
 }
 
-impl Debug for BasicMemoryInfoTag {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("BasicMemoryInfoTag")
-            .field("typ", &{ self.typ })
-            .field("size", &{ self.size })
-            .field("memory_lower", &{ self.memory_lower })
-            .field("memory_upper", &{ self.memory_upper })
-            .finish()
-    }
-}
-
 const EFI_METADATA_SIZE: usize = mem::size_of::<TagTypeId>() + 3 * mem::size_of::<u32>();
 
 /// EFI memory map as per EFI specification.
-#[derive(Debug, ptr_meta::Pointee)]
-#[repr(C)]
+#[derive(ptr_meta::Pointee)]
+// #[derive(Debug, PartialEq, Eq)] // wait for uefi-raw 0.3.0
+#[derive(Debug)]
+#[repr(C, align(8))]
 pub struct EFIMemoryMapTag {
     typ: TagTypeId,
     size: u32,
@@ -306,8 +299,8 @@ impl StructAsBytes for EFIMemoryDesc {
 }
 
 /// EFI ExitBootServices was not called
-#[derive(Debug)]
-#[repr(C)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[repr(C, align(8))]
 pub struct EFIBootServicesNotExited {
     typ: TagTypeId,
     size: u32,

--- a/multiboot2/src/memory_map.rs
+++ b/multiboot2/src/memory_map.rs
@@ -22,9 +22,8 @@ const METADATA_SIZE: usize = mem::size_of::<TagTypeId>() + 3 * mem::size_of::<u3
 /// This tag may not be provided by some boot loaders on EFI platforms if EFI
 /// boot services are enabled and available for the loaded image (The EFI boot
 /// services tag may exist in the Multiboot2 boot information structure).
-#[derive( ptr_meta::Pointee)]
-#[derive(Debug, PartialEq, Eq)]
-#[repr(C, align(8))]
+#[derive(ptr_meta::Pointee, Debug, PartialEq, Eq)]
+#[repr(C)]
 pub struct MemoryMapTag {
     typ: TagTypeId,
     size: u32,
@@ -82,7 +81,7 @@ impl StructAsBytes for MemoryMapTag {
 
 /// A memory area entry descriptor.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[repr(C, align(8))]
+#[repr(C)]
 pub struct MemoryArea {
     base_addr: u64,
     length: u64,
@@ -192,7 +191,7 @@ impl<'a> Iterator for MemoryAreaIter<'a> {
 /// Nowadays, much bigger chunks of continuous memory are available at higher
 /// addresses, but the Multiboot standard still references those two terms.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[repr(C, align(8))]
+#[repr(C)]
 pub struct BasicMemoryInfoTag {
     typ: TagTypeId,
     size: u32,
@@ -232,7 +231,7 @@ const EFI_METADATA_SIZE: usize = mem::size_of::<TagTypeId>() + 3 * mem::size_of:
 #[derive(ptr_meta::Pointee)]
 // #[derive(Debug, PartialEq, Eq)] // wait for uefi-raw 0.3.0
 #[derive(Debug)]
-#[repr(C, align(8))]
+#[repr(C)]
 pub struct EFIMemoryMapTag {
     typ: TagTypeId,
     size: u32,
@@ -300,7 +299,7 @@ impl StructAsBytes for EFIMemoryDesc {
 
 /// EFI ExitBootServices was not called
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[repr(C, align(8))]
+#[repr(C)]
 pub struct EFIBootServicesNotExited {
     typ: TagTypeId,
     size: u32,

--- a/multiboot2/src/module.rs
+++ b/multiboot2/src/module.rs
@@ -14,9 +14,8 @@ const METADATA_SIZE: usize = size_of::<TagTypeId>() + 3 * size_of::<u32>();
 
 /// This tag indicates to the kernel what boot module was loaded along with
 /// the kernel image, and where it can be found.
-#[derive(ptr_meta::Pointee)]
-#[derive(PartialEq, Eq)]
-#[repr(C, align(8))]
+#[derive(ptr_meta::Pointee, PartialEq, Eq)]
+#[repr(C)]
 pub struct ModuleTag {
     typ: TagTypeId,
     size: u32,

--- a/multiboot2/src/module.rs
+++ b/multiboot2/src/module.rs
@@ -14,8 +14,9 @@ const METADATA_SIZE: usize = size_of::<TagTypeId>() + 3 * size_of::<u32>();
 
 /// This tag indicates to the kernel what boot module was loaded along with
 /// the kernel image, and where it can be found.
-#[repr(C, packed)] // only repr(C) would add unwanted padding near name_byte.
 #[derive(ptr_meta::Pointee)]
+#[derive(PartialEq, Eq)]
+#[repr(C, align(8))]
 pub struct ModuleTag {
     typ: TagTypeId,
     size: u32,

--- a/multiboot2/src/rsdp.rs
+++ b/multiboot2/src/rsdp.rs
@@ -24,7 +24,7 @@ const RSDPV1_LENGTH: usize = 20;
 
 /// This tag contains a copy of RSDP as defined per ACPI 1.0 specification.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[repr(C, align(8))]
+#[repr(C)]
 pub struct RsdpV1Tag {
     typ: TagTypeId,
     size: u32,
@@ -97,7 +97,7 @@ impl StructAsBytes for RsdpV1Tag {
 
 /// This tag contains a copy of RSDP as defined per ACPI 2.0 or later specification.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[repr(C, align(8))]
+#[repr(C)]
 pub struct RsdpV2Tag {
     typ: TagTypeId,
     size: u32,

--- a/multiboot2/src/rsdp.rs
+++ b/multiboot2/src/rsdp.rs
@@ -23,8 +23,8 @@ use {
 const RSDPV1_LENGTH: usize = 20;
 
 /// This tag contains a copy of RSDP as defined per ACPI 1.0 specification.
-#[derive(Clone, Copy, Debug)]
-#[repr(C, packed)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[repr(C, align(8))]
 pub struct RsdpV1Tag {
     typ: TagTypeId,
     size: u32,
@@ -96,8 +96,8 @@ impl StructAsBytes for RsdpV1Tag {
 }
 
 /// This tag contains a copy of RSDP as defined per ACPI 2.0 or later specification.
-#[derive(Clone, Copy, Debug)]
-#[repr(C, packed)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[repr(C, align(8))]
 pub struct RsdpV2Tag {
     typ: TagTypeId,
     size: u32,

--- a/multiboot2/src/smbios.rs
+++ b/multiboot2/src/smbios.rs
@@ -11,9 +11,8 @@ const METADATA_SIZE: usize = core::mem::size_of::<TagTypeId>()
     + core::mem::size_of::<u8>() * 8;
 
 /// This tag contains a copy of SMBIOS tables as well as their version.
-#[derive(ptr_meta::Pointee)]
-#[derive(PartialEq, Eq)]
-#[repr(C, align(8))]
+#[derive(ptr_meta::Pointee, PartialEq, Eq)]
+#[repr(C)]
 pub struct SmbiosTag {
     typ: TagTypeId,
     size: u32,

--- a/multiboot2/src/smbios.rs
+++ b/multiboot2/src/smbios.rs
@@ -12,7 +12,8 @@ const METADATA_SIZE: usize = core::mem::size_of::<TagTypeId>()
 
 /// This tag contains a copy of SMBIOS tables as well as their version.
 #[derive(ptr_meta::Pointee)]
-#[repr(C, packed)]
+#[derive(PartialEq, Eq)]
+#[repr(C, align(8))]
 pub struct SmbiosTag {
     typ: TagTypeId,
     size: u32,

--- a/multiboot2/src/tag_type.rs
+++ b/multiboot2/src/tag_type.rs
@@ -33,7 +33,7 @@ impl TagTypeId {
 /// to a specific semantic according to the specification. Additionally, it
 /// allows to use the [`TagType::Custom`] variant. It is **not binary compatible**
 /// with [`TagTypeId`].
-#[derive(Copy, Clone, Debug, PartialOrd, PartialEq, Eq, Ord, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum TagType {
     /// Tag `0`: Marks the end of the tags.
     End,

--- a/multiboot2/src/vbe_info.rs
+++ b/multiboot2/src/vbe_info.rs
@@ -3,8 +3,8 @@ use core::fmt;
 
 /// This tag contains VBE metadata, VBE controller information returned by the
 /// VBE Function 00h and VBE mode information returned by the VBE Function 01h.
-#[derive(Debug, Copy, Clone)]
-#[repr(C, packed)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[repr(C, align(8))]
 pub struct VBEInfoTag {
     typ: TagTypeId,
     length: u32,
@@ -45,7 +45,7 @@ pub struct VBEInfoTag {
 ///
 /// The purpose of this struct is to provide information to the kernel about the general
 /// capabilities of the installed VBE software and hardware.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 #[repr(C, packed)]
 pub struct VBEControlInfo {
     /// VBE Signature aka "VESA".
@@ -106,7 +106,7 @@ impl fmt::Debug for VBEControlInfo {
 
 /// Extended information about a specific VBE display mode from the
 /// mode list returned by `VBEControlInfo` (VBE Function `00h`).
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 #[repr(C, packed)]
 pub struct VBEModeInfo {
     /// Mode attributes.
@@ -234,7 +234,7 @@ impl fmt::Debug for VBEModeInfo {
 /// A VBE colour field.
 ///
 /// Describes the size and position of some colour capability.
-#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[repr(C, packed)]
 pub struct VBEField {
     /// The size, in bits, of the color components of a direct color pixel.
@@ -335,7 +335,7 @@ bitflags! {
 }
 
 /// The MemoryModel field specifies the general type of memory organization used in modes.
-#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(u8)]
 #[allow(missing_docs)]
 #[allow(clippy::upper_case_acronyms)]

--- a/multiboot2/src/vbe_info.rs
+++ b/multiboot2/src/vbe_info.rs
@@ -4,7 +4,7 @@ use core::fmt;
 /// This tag contains VBE metadata, VBE controller information returned by the
 /// VBE Function 00h and VBE mode information returned by the VBE Function 01h.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[repr(C, align(8))]
+#[repr(C)]
 pub struct VBEInfoTag {
     typ: TagTypeId,
     length: u32,


### PR DESCRIPTION
- streamline default derives
- removed packed where it is not needed (because the default C representation is already packed)