### PR TITLE
tree-wide: streamline default derives (also Hash everywhere)

### DIFF
--- a/multiboot2-header/src/address.rs
+++ b/multiboot2-header/src/address.rs
@@ -5,7 +5,7 @@ use core::mem::size_of;
 /// format, but it must be provided if the image is in a.out format or in some
 /// other format. Required for legacy boot (BIOS).
 /// Determines load addresses.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 pub struct AddressHeaderTag {
     typ: HeaderTagType,

--- a/multiboot2-header/src/console.rs
+++ b/multiboot2-header/src/console.rs
@@ -13,7 +13,7 @@ pub enum ConsoleHeaderTagFlags {
 
 /// Tells that a console must be available in MBI.
 /// Only relevant for legacy BIOS.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 pub struct ConsoleHeaderTag {
     typ: HeaderTagType,

--- a/multiboot2-header/src/end.rs
+++ b/multiboot2-header/src/end.rs
@@ -2,7 +2,7 @@ use crate::{HeaderTagFlag, HeaderTagType};
 use core::mem::size_of;
 
 /// Terminates a list of optional tags in a Multiboot2 header.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 pub struct EndHeaderTag {
     // u16 value

--- a/multiboot2-header/src/entry_address.rs
+++ b/multiboot2-header/src/entry_address.rs
@@ -5,7 +5,7 @@ use core::mem::size_of;
 
 /// Specifies the physical address to which the boot loader should jump in
 /// order to start running the operating system. Not needed for ELF files.
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 pub struct EntryAddressHeaderTag {
     typ: HeaderTagType,

--- a/multiboot2-header/src/entry_efi_32.rs
+++ b/multiboot2-header/src/entry_efi_32.rs
@@ -9,7 +9,7 @@ use core::mem::size_of;
 ///
 /// Technically, this is equivalent to the [`crate::EntryAddressHeaderTag`] but with a different
 /// [`crate::HeaderTagType`].
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 pub struct EntryEfi32HeaderTag {
     typ: HeaderTagType,

--- a/multiboot2-header/src/entry_efi_64.rs
+++ b/multiboot2-header/src/entry_efi_64.rs
@@ -9,7 +9,7 @@ use core::mem::size_of;
 ///
 /// Technically, this is equivalent to the [`crate::EntryAddressHeaderTag`] but with a different
 /// [`crate::HeaderTagType`].
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 pub struct EntryEfi64HeaderTag {
     typ: HeaderTagType,

--- a/multiboot2-header/src/framebuffer.rs
+++ b/multiboot2-header/src/framebuffer.rs
@@ -5,7 +5,7 @@ use core::mem::size_of;
 /// is present the bootloader assumes that the payload
 /// has framebuffer support. Note: This is only a
 /// recommended mode. Only relevant on legacy BIOS.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 pub struct FramebufferHeaderTag {
     typ: HeaderTagType,

--- a/multiboot2-header/src/header.rs
+++ b/multiboot2-header/src/header.rs
@@ -226,7 +226,7 @@ impl core::error::Error for LoadError {}
 ///
 /// The "basic" Multiboot2 header. This means only the properties, that are known during
 /// compile time. All other information are derived during runtime from the size property.
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 pub struct Multiboot2BasicHeader {
     /// Must be the value of [`MULTIBOOT2_HEADER_MAGIC`].

--- a/multiboot2-header/src/information_request.rs
+++ b/multiboot2-header/src/information_request.rs
@@ -8,7 +8,7 @@ use multiboot2::TagType;
 
 /// Specifies what specific tag types the bootloader should provide
 /// inside the mbi.
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 pub struct InformationRequestHeaderTag<const N: usize> {
     typ: HeaderTagType,

--- a/multiboot2-header/src/module_align.rs
+++ b/multiboot2-header/src/module_align.rs
@@ -2,7 +2,7 @@ use crate::{HeaderTagFlag, HeaderTagType};
 use core::mem::size_of;
 
 /// If this tag is present, provided boot modules must be page aligned.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 pub struct ModuleAlignHeaderTag {
     typ: HeaderTagType,

--- a/multiboot2-header/src/relocatable.rs
+++ b/multiboot2-header/src/relocatable.rs
@@ -19,7 +19,7 @@ pub enum RelocatableHeaderTagPreference {
 }
 
 /// This tag indicates that the image is relocatable.
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 pub struct RelocatableHeaderTag {
     typ: HeaderTagType,

--- a/multiboot2-header/src/tags.rs
+++ b/multiboot2-header/src/tags.rs
@@ -63,7 +63,7 @@ pub enum HeaderTagFlag {
 /// Common properties for all header tags. Other tags may have additional fields
 /// that depend on the `typ` and the `size` field. All tags share the same beginning of the
 /// struct.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 pub struct HeaderTag {
     // u16 value

--- a/multiboot2-header/src/uefi_bs.rs
+++ b/multiboot2-header/src/uefi_bs.rs
@@ -3,7 +3,7 @@ use core::mem::size_of;
 
 /// This tag indicates that payload supports starting without terminating UEFI boot services.
 /// Or in other words: The payload wants to use UEFI boot services.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 pub struct EfiBootServiceHeaderTag {
     typ: HeaderTagType,

--- a/multiboot2/src/boot_loader_name.rs
+++ b/multiboot2/src/boot_loader_name.rs
@@ -12,7 +12,7 @@ use {
 const METADATA_SIZE: usize = size_of::<TagTypeId>() + size_of::<u32>();
 
 /// The bootloader name tag.
-#[derive(ptr_meta::Pointee, PartialEq, Eq)]
+#[derive(ptr_meta::Pointee, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 pub struct BootLoaderNameTag {
     typ: TagTypeId,

--- a/multiboot2/src/command_line.rs
+++ b/multiboot2/src/command_line.rs
@@ -18,7 +18,7 @@ pub(crate) const METADATA_SIZE: usize = mem::size_of::<TagTypeId>() + mem::size_
 ///
 /// The string is a normal C-style UTF-8 zero-terminated string that can be
 /// obtained via the `command_line` method.
-#[derive(ptr_meta::Pointee, PartialEq, Eq)]
+#[derive(ptr_meta::Pointee, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 pub struct CommandLineTag {
     typ: TagTypeId,

--- a/multiboot2/src/efi.rs
+++ b/multiboot2/src/efi.rs
@@ -9,7 +9,7 @@ use core::mem::size_of;
 use crate::builder::traits::StructAsBytes;
 
 /// EFI system table in 32 bit mode
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 pub struct EFISdt32 {
     typ: TagTypeId,
@@ -41,7 +41,7 @@ impl StructAsBytes for EFISdt32 {
 }
 
 /// EFI system table in 64 bit mode
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 pub struct EFISdt64 {
     typ: TagTypeId,
@@ -73,7 +73,7 @@ impl StructAsBytes for EFISdt64 {
 }
 
 /// Contains pointer to boot loader image handle.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 pub struct EFIImageHandle32 {
     typ: TagTypeId,
@@ -105,7 +105,7 @@ impl StructAsBytes for EFIImageHandle32 {
 }
 
 /// Contains pointer to boot loader image handle.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 pub struct EFIImageHandle64 {
     typ: TagTypeId,

--- a/multiboot2/src/elf_sections.rs
+++ b/multiboot2/src/elf_sections.rs
@@ -142,7 +142,7 @@ impl Default for ElfSectionIter {
 }
 
 /// A single generic ELF Section.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ElfSection {
     inner: *const u8,
     string_section: *const u8,

--- a/multiboot2/src/framebuffer.rs
+++ b/multiboot2/src/framebuffer.rs
@@ -220,7 +220,7 @@ impl PartialEq for FramebufferTag {
 }
 
 /// Helper struct for [`FramebufferType`].
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(u8)]
 #[allow(clippy::upper_case_acronyms)]
 enum FramebufferTypeId {

--- a/multiboot2/src/image_load_addr.rs
+++ b/multiboot2/src/image_load_addr.rs
@@ -7,7 +7,7 @@ use {
 
 /// If the image has relocatable header tag, this tag contains the image's
 /// base physical address.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 pub struct ImageLoadPhysAddr {
     typ: TagTypeId,

--- a/multiboot2/src/memory_map.rs
+++ b/multiboot2/src/memory_map.rs
@@ -80,7 +80,7 @@ impl StructAsBytes for MemoryMapTag {
 }
 
 /// A memory area entry descriptor.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 pub struct MemoryArea {
     base_addr: u64,
@@ -190,7 +190,7 @@ impl<'a> Iterator for MemoryAreaIter<'a> {
 /// (which had a 24-bit address bus) could use, historically.
 /// Nowadays, much bigger chunks of continuous memory are available at higher
 /// addresses, but the Multiboot standard still references those two terms.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 pub struct BasicMemoryInfoTag {
     typ: TagTypeId,
@@ -298,7 +298,7 @@ impl StructAsBytes for EFIMemoryDesc {
 }
 
 /// EFI ExitBootServices was not called
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 pub struct EFIBootServicesNotExited {
     typ: TagTypeId,

--- a/multiboot2/src/module.rs
+++ b/multiboot2/src/module.rs
@@ -14,7 +14,7 @@ const METADATA_SIZE: usize = size_of::<TagTypeId>() + 3 * size_of::<u32>();
 
 /// This tag indicates to the kernel what boot module was loaded along with
 /// the kernel image, and where it can be found.
-#[derive(ptr_meta::Pointee, PartialEq, Eq)]
+#[derive(ptr_meta::Pointee, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 pub struct ModuleTag {
     typ: TagTypeId,

--- a/multiboot2/src/rsdp.rs
+++ b/multiboot2/src/rsdp.rs
@@ -23,7 +23,7 @@ use {
 const RSDPV1_LENGTH: usize = 20;
 
 /// This tag contains a copy of RSDP as defined per ACPI 1.0 specification.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 pub struct RsdpV1Tag {
     typ: TagTypeId,
@@ -96,7 +96,7 @@ impl StructAsBytes for RsdpV1Tag {
 }
 
 /// This tag contains a copy of RSDP as defined per ACPI 2.0 or later specification.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 pub struct RsdpV2Tag {
     typ: TagTypeId,

--- a/multiboot2/src/smbios.rs
+++ b/multiboot2/src/smbios.rs
@@ -11,7 +11,7 @@ const METADATA_SIZE: usize = core::mem::size_of::<TagTypeId>()
     + core::mem::size_of::<u8>() * 8;
 
 /// This tag contains a copy of SMBIOS tables as well as their version.
-#[derive(ptr_meta::Pointee, PartialEq, Eq)]
+#[derive(ptr_meta::Pointee, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 pub struct SmbiosTag {
     typ: TagTypeId,

--- a/multiboot2/src/vbe_info.rs
+++ b/multiboot2/src/vbe_info.rs
@@ -3,7 +3,7 @@ use core::fmt;
 
 /// This tag contains VBE metadata, VBE controller information returned by the
 /// VBE Function 00h and VBE mode information returned by the VBE Function 01h.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 pub struct VBEInfoTag {
     typ: TagTypeId,
@@ -45,7 +45,7 @@ pub struct VBEInfoTag {
 ///
 /// The purpose of this struct is to provide information to the kernel about the general
 /// capabilities of the installed VBE software and hardware.
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C, packed)]
 pub struct VBEControlInfo {
     /// VBE Signature aka "VESA".
@@ -106,7 +106,7 @@ impl fmt::Debug for VBEControlInfo {
 
 /// Extended information about a specific VBE display mode from the
 /// mode list returned by `VBEControlInfo` (VBE Function `00h`).
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C, packed)]
 pub struct VBEModeInfo {
     /// Mode attributes.
@@ -234,7 +234,7 @@ impl fmt::Debug for VBEModeInfo {
 /// A VBE colour field.
 ///
 /// Describes the size and position of some colour capability.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C, packed)]
 pub struct VBEField {
     /// The size, in bits, of the color components of a direct color pixel.
@@ -247,7 +247,7 @@ pub struct VBEField {
 
 bitflags! {
     /// The Capabilities field indicates the support of specific features in the graphics environment.
-    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
     #[repr(transparent)]
     pub struct VBECapabilities: u32 {
         /// Can the DAC be switched between 6 and 8 bit modes.
@@ -265,7 +265,7 @@ bitflags! {
 
 bitflags! {
     /// A Mode attributes bitfield.
-    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
     #[repr(transparent)]
     pub struct VBEModeAttributes: u16 {
         /// Mode supported by hardware configuration.
@@ -298,7 +298,7 @@ bitflags! {
 bitflags! {
     /// The WindowAttributes describe the characteristics of the CPU windowing
     /// scheme such as whether the windows exist and are read/writeable, as follows:
-    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
     #[repr(transparent)]
     pub struct VBEWindowAttributes: u8 {
         /// Relocatable window(s) supported?
@@ -323,7 +323,7 @@ bitflags! {
     /// (it is assumed all color ramp data is 8 bits per primary).
     /// Bit D1 specifies whether the bits in the Rsvd field of the direct color
     /// pixel can be used by the application or are reserved, and thus unusable.
-    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
     #[repr(transparent)]
     pub struct VBEDirectColorAttributes: u8 {
         /// Color ramp is fixed when cleared and programmable when set.


### PR DESCRIPTION
This doesn't have a big negative impact but gives library users more freedom.