### PR TITLE
fix memory issue in memory-map

### DIFF
--- a/multiboot2/Changelog.md
+++ b/multiboot2/Changelog.md
@@ -14,6 +14,8 @@
 - `EFIMemoryAreaType` was removed and is now an alias of
   `uefi_raw::table::boot::MemoryType`
 - MSRV is 1.68.0
+- **BREAKING** Removed `MemoryAreaIter` and `MemoryMapTag::available_memory_areas`
+- Added `MemoryMapTag::entry_size` and `MemoryMapTag::entry_version`
 
 ## 0.15.1 (2023-03-18)
 - **BREAKING** `MemoryMapTag::all_memory_areas()` was renamed to `memory_areas`


### PR DESCRIPTION
Via git-bisecting, I could find that https://github.com/rust-osdev/multiboot2/commit/d198dceffe544b6324ba4c204270d9a1d934abba broke something with the (legacy) memory map tag. This MR fixes the problem and adds a unit test for it.

Also see: https://github.com/rust-osdev/multiboot2/pull/133