### PR TITLE
multiboot2: memory-map: derive Eq + uefi-raw@0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,9 +95,9 @@ dependencies = [
 
 [[package]]
 name = "uefi-raw"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d73e08d8e944b7c7e90a7c8a53213bdd71ceb7b414ee664f522c1cc579888c25"
+checksum = "62642516099c6441a5f41b0da8486d5fc3515a0603b0fdaea67b31600e22082e"
 dependencies = [
  "bitflags",
  "ptr_meta",

--- a/multiboot2/Cargo.toml
+++ b/multiboot2/Cargo.toml
@@ -45,5 +45,5 @@ bitflags.workspace = true
 derive_more.workspace = true
 log.workspace = true
 
-uefi-raw = { version = "0.2.0", default-features = false }
-ptr_meta = { version = "0.2.0", default-features = false }
+uefi-raw = { version = "0.3", default-features = false }
+ptr_meta = { version = "0.2", default-features = false }

--- a/multiboot2/Changelog.md
+++ b/multiboot2/Changelog.md
@@ -17,7 +17,11 @@
 - **BREAKING** Removed `MemoryAreaIter` and `MemoryMapTag::available_memory_areas`
 - Added `MemoryMapTag::entry_size` and `MemoryMapTag::entry_version`
 - **BREAKING** Renamed `BootInformation::load_base_addr` to `BootInformation::load_base_addr_tag`
+- **BREAKING** Renamed `BootInformation::efi_32_ih` to `BootInformation::efi_32_ih_tag`
+- **BREAKING** Renamed `BootInformation::efi_32_ih` to `BootInformation::efi_32_ih_tag`
 - **BREAKING** Renamed `ImageLoadPhysAddr` to `ImageLoadPhysAddrTag`
+- **BREAKING** Renamed `EFIImageHandle32` to `EFIImageHandle32Tag`
+- **BREAKING** Renamed `EFIImageHandle64` to `EFIImageHandle64Tag`
 
 ## 0.15.1 (2023-03-18)
 - **BREAKING** `MemoryMapTag::all_memory_areas()` was renamed to `memory_areas`

--- a/multiboot2/Changelog.md
+++ b/multiboot2/Changelog.md
@@ -16,6 +16,8 @@
 - MSRV is 1.68.0
 - **BREAKING** Removed `MemoryAreaIter` and `MemoryMapTag::available_memory_areas`
 - Added `MemoryMapTag::entry_size` and `MemoryMapTag::entry_version`
+- **BREAKING** Renamed `BootInformation::load_base_addr` to `BootInformation::load_base_addr_tag`
+- **BREAKING** Renamed `ImageLoadPhysAddr` to `ImageLoadPhysAddrTag`
 
 ## 0.15.1 (2023-03-18)
 - **BREAKING** `MemoryMapTag::all_memory_areas()` was renamed to `memory_areas`

--- a/multiboot2/src/builder/information.rs
+++ b/multiboot2/src/builder/information.rs
@@ -14,8 +14,7 @@ use core::mem::size_of;
 /// Builder to construct a valid Multiboot2 information dynamically at runtime.
 /// The tags will appear in the order of their corresponding enumeration,
 /// except for the END tag.
-#[derive(Debug)]
-// #[derive(Debug, PartialEq, Eq)] // wait for uefi-raw 0.3.0
+#[derive(Debug, PartialEq, Eq)]
 pub struct InformationBuilder {
     basic_memory_info_tag: Option<BasicMemoryInfoTag>,
     boot_loader_name_tag: Option<Box<BootLoaderNameTag>>,

--- a/multiboot2/src/builder/information.rs
+++ b/multiboot2/src/builder/information.rs
@@ -2,7 +2,7 @@
 use crate::builder::traits::StructAsBytes;
 use crate::{
     BasicMemoryInfoTag, BootInformationInner, BootLoaderNameTag, CommandLineTag,
-    EFIBootServicesNotExited, EFIImageHandle32, EFIImageHandle64, EFIMemoryMapTag, EFISdt32,
+    EFIBootServicesNotExited, EFIImageHandle32Tag, EFIImageHandle64Tag, EFIMemoryMapTag, EFISdt32,
     EFISdt64, ElfSectionsTag, EndTag, FramebufferTag, ImageLoadPhysAddrTag, MemoryMapTag,
     ModuleTag, RsdpV1Tag, RsdpV2Tag, SmbiosTag,
 };
@@ -20,8 +20,8 @@ pub struct InformationBuilder {
     boot_loader_name_tag: Option<Box<BootLoaderNameTag>>,
     command_line_tag: Option<Box<CommandLineTag>>,
     efi_boot_services_not_exited: Option<EFIBootServicesNotExited>,
-    efi_image_handle32: Option<EFIImageHandle32>,
-    efi_image_handle64: Option<EFIImageHandle64>,
+    efi_image_handle32: Option<EFIImageHandle32Tag>,
+    efi_image_handle64: Option<EFIImageHandle64Tag>,
     efi_memory_map_tag: Option<Box<EFIMemoryMapTag>>,
     elf_sections_tag: Option<Box<ElfSectionsTag>>,
     framebuffer_tag: Option<Box<FramebufferTag>>,
@@ -241,11 +241,11 @@ impl InformationBuilder {
         self.efi_boot_services_not_exited = Some(EFIBootServicesNotExited::new());
     }
 
-    pub fn efi_image_handle32(&mut self, efi_image_handle32: EFIImageHandle32) {
+    pub fn efi_image_handle32(&mut self, efi_image_handle32: EFIImageHandle32Tag) {
         self.efi_image_handle32 = Some(efi_image_handle32);
     }
 
-    pub fn efi_image_handle64(&mut self, efi_image_handle64: EFIImageHandle64) {
+    pub fn efi_image_handle64(&mut self, efi_image_handle64: EFIImageHandle64Tag) {
         self.efi_image_handle64 = Some(efi_image_handle64);
     }
 

--- a/multiboot2/src/builder/information.rs
+++ b/multiboot2/src/builder/information.rs
@@ -3,7 +3,7 @@ use crate::builder::traits::StructAsBytes;
 use crate::{
     BasicMemoryInfoTag, BootInformationInner, BootLoaderNameTag, CommandLineTag,
     EFIBootServicesNotExited, EFIImageHandle32, EFIImageHandle64, EFIMemoryMapTag, EFISdt32,
-    EFISdt64, ElfSectionsTag, EndTag, FramebufferTag, ImageLoadPhysAddr, MemoryMapTag, ModuleTag,
+    EFISdt64, ElfSectionsTag, EndTag, FramebufferTag, ImageLoadPhysAddrTag, MemoryMapTag, ModuleTag,
     RsdpV1Tag, RsdpV2Tag, SmbiosTag,
 };
 
@@ -25,7 +25,7 @@ pub struct InformationBuilder {
     efi_memory_map_tag: Option<Box<EFIMemoryMapTag>>,
     elf_sections_tag: Option<Box<ElfSectionsTag>>,
     framebuffer_tag: Option<Box<FramebufferTag>>,
-    image_load_addr: Option<ImageLoadPhysAddr>,
+    image_load_addr: Option<ImageLoadPhysAddrTag>,
     memory_map_tag: Option<Box<MemoryMapTag>>,
     module_tags: Vec<Box<ModuleTag>>,
     efisdt32: Option<EFISdt32>,
@@ -261,7 +261,7 @@ impl InformationBuilder {
         self.framebuffer_tag = Some(framebuffer_tag);
     }
 
-    pub fn image_load_addr(&mut self, image_load_addr: ImageLoadPhysAddr) {
+    pub fn image_load_addr(&mut self, image_load_addr: ImageLoadPhysAddrTag) {
         self.image_load_addr = Some(image_load_addr);
     }
 

--- a/multiboot2/src/builder/information.rs
+++ b/multiboot2/src/builder/information.rs
@@ -3,8 +3,8 @@ use crate::builder::traits::StructAsBytes;
 use crate::{
     BasicMemoryInfoTag, BootInformationInner, BootLoaderNameTag, CommandLineTag,
     EFIBootServicesNotExited, EFIImageHandle32, EFIImageHandle64, EFIMemoryMapTag, EFISdt32,
-    EFISdt64, ElfSectionsTag, EndTag, FramebufferTag, ImageLoadPhysAddrTag, MemoryMapTag, ModuleTag,
-    RsdpV1Tag, RsdpV2Tag, SmbiosTag,
+    EFISdt64, ElfSectionsTag, EndTag, FramebufferTag, ImageLoadPhysAddrTag, MemoryMapTag,
+    ModuleTag, RsdpV1Tag, RsdpV2Tag, SmbiosTag,
 };
 
 use alloc::boxed::Box;

--- a/multiboot2/src/efi.rs
+++ b/multiboot2/src/efi.rs
@@ -72,16 +72,17 @@ impl StructAsBytes for EFISdt64 {
     }
 }
 
-/// Contains pointer to boot loader image handle.
+/// Tag that contains the pointer to the boot loader's UEFI image handle
+/// (32-bit).
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
-pub struct EFIImageHandle32 {
+pub struct EFIImageHandle32Tag {
     typ: TagTypeId,
     size: u32,
     pointer: u32,
 }
 
-impl EFIImageHandle32 {
+impl EFIImageHandle32Tag {
     #[cfg(feature = "builder")]
     pub fn new(pointer: u32) -> Self {
         Self {
@@ -98,22 +99,23 @@ impl EFIImageHandle32 {
 }
 
 #[cfg(feature = "builder")]
-impl StructAsBytes for EFIImageHandle32 {
+impl StructAsBytes for EFIImageHandle32Tag {
     fn byte_size(&self) -> usize {
         size_of::<Self>()
     }
 }
 
-/// Contains pointer to boot loader image handle.
+/// Tag that contains the pointer to the boot loader's UEFI image handle
+/// (64-bit).
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
-pub struct EFIImageHandle64 {
+pub struct EFIImageHandle64Tag {
     typ: TagTypeId,
     size: u32,
     pointer: u64,
 }
 
-impl EFIImageHandle64 {
+impl EFIImageHandle64Tag {
     #[cfg(feature = "builder")]
     pub fn new(pointer: u64) -> Self {
         Self {
@@ -130,7 +132,7 @@ impl EFIImageHandle64 {
 }
 
 #[cfg(feature = "builder")]
-impl StructAsBytes for EFIImageHandle64 {
+impl StructAsBytes for EFIImageHandle64Tag {
     fn byte_size(&self) -> usize {
         size_of::<Self>()
     }
@@ -138,7 +140,7 @@ impl StructAsBytes for EFIImageHandle64 {
 
 #[cfg(all(test, feature = "builder"))]
 mod tests {
-    use super::{EFIImageHandle32, EFIImageHandle64, EFISdt32, EFISdt64};
+    use super::{EFIImageHandle32Tag, EFIImageHandle64Tag, EFISdt32, EFISdt64};
 
     const ADDR: usize = 0xABCDEF;
 
@@ -156,13 +158,13 @@ mod tests {
 
     #[test]
     fn test_build_eftih32() {
-        let tag = EFIImageHandle32::new(ADDR.try_into().unwrap());
+        let tag = EFIImageHandle32Tag::new(ADDR.try_into().unwrap());
         assert_eq!(tag.image_handle(), ADDR);
     }
 
     #[test]
     fn test_build_eftih64() {
-        let tag = EFIImageHandle64::new(ADDR.try_into().unwrap());
+        let tag = EFIImageHandle64Tag::new(ADDR.try_into().unwrap());
         assert_eq!(tag.image_handle(), ADDR);
     }
 }

--- a/multiboot2/src/image_load_addr.rs
+++ b/multiboot2/src/image_load_addr.rs
@@ -9,13 +9,13 @@ use {
 /// base physical address.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
-pub struct ImageLoadPhysAddr {
+pub struct ImageLoadPhysAddrTag {
     typ: TagTypeId,
     size: u32,
     load_base_addr: u32,
 }
 
-impl ImageLoadPhysAddr {
+impl ImageLoadPhysAddrTag {
     #[cfg(feature = "builder")]
     pub fn new(load_base_addr: u32) -> Self {
         Self {
@@ -32,7 +32,7 @@ impl ImageLoadPhysAddr {
 }
 
 #[cfg(feature = "builder")]
-impl StructAsBytes for ImageLoadPhysAddr {
+impl StructAsBytes for ImageLoadPhysAddrTag {
     fn byte_size(&self) -> usize {
         size_of::<Self>()
     }
@@ -40,13 +40,13 @@ impl StructAsBytes for ImageLoadPhysAddr {
 
 #[cfg(all(test, feature = "builder"))]
 mod tests {
-    use super::ImageLoadPhysAddr;
+    use super::ImageLoadPhysAddrTag;
 
     const ADDR: u32 = 0xABCDEF;
 
     #[test]
     fn test_build_load_addr() {
-        let tag = ImageLoadPhysAddr::new(ADDR);
+        let tag = ImageLoadPhysAddrTag::new(ADDR);
         assert_eq!(tag.load_base_addr(), ADDR);
     }
 }

--- a/multiboot2/src/lib.rs
+++ b/multiboot2/src/lib.rs
@@ -55,7 +55,7 @@ pub use elf_sections::{
     ElfSection, ElfSectionFlags, ElfSectionIter, ElfSectionType, ElfSectionsTag,
 };
 pub use framebuffer::{FramebufferColor, FramebufferField, FramebufferTag, FramebufferType};
-pub use image_load_addr::ImageLoadPhysAddr;
+pub use image_load_addr::ImageLoadPhysAddrTag;
 pub use memory_map::{
     BasicMemoryInfoTag, EFIBootServicesNotExited, EFIMemoryAreaType, EFIMemoryDesc,
     EFIMemoryMapTag, MemoryArea, MemoryAreaType, MemoryMapTag,
@@ -335,19 +335,19 @@ impl BootInformation {
         }
     }
 
-    /// Search for the EFI 32-bit image handle pointer.
+    /// Search for the EFI 32-bit image handle pointer tag.
     pub fn efi_32_ih(&self) -> Option<&EFIImageHandle32> {
         self.get_tag::<EFIImageHandle32, _>(TagType::Efi32Ih)
     }
 
-    /// Search for the EFI 64-bit image handle pointer.
+    /// Search for the EFI 64-bit image handle pointer tag.
     pub fn efi_64_ih(&self) -> Option<&EFIImageHandle64> {
         self.get_tag::<EFIImageHandle64, _>(TagType::Efi64Ih)
     }
 
-    /// Search for the Image Load Base Physical Address.
-    pub fn load_base_addr(&self) -> Option<&ImageLoadPhysAddr> {
-        self.get_tag::<ImageLoadPhysAddr, _>(TagType::LoadBaseAddr)
+    /// Search for the Image Load Base Physical Address tag.
+    pub fn load_base_addr_tag(&self) -> Option<&ImageLoadPhysAddrTag> {
+        self.get_tag::<ImageLoadPhysAddrTag, _>(TagType::LoadBaseAddr)
     }
 
     /// Search for the VBE information tag.
@@ -496,8 +496,8 @@ impl fmt::Debug for BootInformation {
             .field("efi_32_ih", &self.efi_32_ih())
             .field("efi_64_ih", &self.efi_64_ih())
             .field("efi_sdt_32_tag", &self.efi_sdt_32_tag())
-            .field("efi_sdt_64_tag", &self.efi_sdt_64_tag())
-            .field("efi_memory_map_tag", &self.efi_memory_map_tag())
+            .field("efi_sdt_64_tag", &self.efi_sdt_64())
+            .field("efi_memory_map_tag", &self.efi_memory_map())
             .finish()
     }
 }
@@ -868,8 +868,8 @@ mod tests {
         assert_eq!(addr, bi.start_address());
         assert_eq!(addr + bytes.0.len(), bi.end_address());
         assert_eq!(bytes.0.len(), bi.total_size());
-        assert!(bi.vbe_info_tag().is_some());
-        let vbe = bi.vbe_info_tag().unwrap();
+        assert!(bi.vbe_info().is_some());
+        let vbe = bi.vbe_info().unwrap();
         use vbe_info::*;
 
         assert_eq!({ vbe.mode }, 16762);
@@ -1345,7 +1345,7 @@ mod tests {
         assert!(mm.next().is_none());
 
         // Test the RSDP tag
-        let rsdp_old = bi.rsdp_v1_tag().unwrap();
+        let rsdp_old = bi.rsdp_v1().unwrap();
         assert_eq!("RSD PTR ", rsdp_old.signature().unwrap());
         assert!(rsdp_old.checksum_is_valid());
         assert_eq!("BOCHS ", rsdp_old.oem_id().unwrap());
@@ -1487,7 +1487,7 @@ mod tests {
         assert_eq!(addr, bi.start_address());
         assert_eq!(addr + bytes.0.len(), bi.end_address());
         assert_eq!(bytes.0.len(), bi.total_size());
-        let efi_memory_map = bi.efi_memory_map_tag().unwrap();
+        let efi_memory_map = bi.efi_memory_map().unwrap();
         let mut efi_mmap_iter = efi_memory_map.memory_areas();
         let desc = efi_mmap_iter.next().unwrap();
         assert_eq!(desc.phys_start, 0x100000);
@@ -1520,7 +1520,7 @@ mod tests {
         ]);
         let bi = unsafe { load(bytes2.0.as_ptr() as usize) };
         let bi = bi.unwrap();
-        let efi_mmap = bi.efi_memory_map_tag();
+        let efi_mmap = bi.efi_memory_map();
         assert!(efi_mmap.is_none());
     }
 

--- a/multiboot2/src/lib.rs
+++ b/multiboot2/src/lib.rs
@@ -868,8 +868,8 @@ mod tests {
         assert_eq!(addr, bi.start_address());
         assert_eq!(addr + bytes.0.len(), bi.end_address());
         assert_eq!(bytes.0.len(), bi.total_size());
-        assert!(bi.vbe_info().is_some());
-        let vbe = bi.vbe_info().unwrap();
+        assert!(bi.vbe_info_tag().is_some());
+        let vbe = bi.vbe_info_tag().unwrap();
         use vbe_info::*;
 
         assert_eq!({ vbe.mode }, 16762);
@@ -1345,7 +1345,7 @@ mod tests {
         assert!(mm.next().is_none());
 
         // Test the RSDP tag
-        let rsdp_old = bi.rsdp_v1().unwrap();
+        let rsdp_old = bi.rsdp_v1_tag().unwrap();
         assert_eq!("RSD PTR ", rsdp_old.signature().unwrap());
         assert!(rsdp_old.checksum_is_valid());
         assert_eq!("BOCHS ", rsdp_old.oem_id().unwrap());
@@ -1487,7 +1487,7 @@ mod tests {
         assert_eq!(addr, bi.start_address());
         assert_eq!(addr + bytes.0.len(), bi.end_address());
         assert_eq!(bytes.0.len(), bi.total_size());
-        let efi_memory_map = bi.efi_memory_map().unwrap();
+        let efi_memory_map = bi.efi_memory_map_tag().unwrap();
         let mut efi_mmap_iter = efi_memory_map.memory_areas();
         let desc = efi_mmap_iter.next().unwrap();
         assert_eq!(desc.phys_start, 0x100000);
@@ -1520,7 +1520,7 @@ mod tests {
         ]);
         let bi = unsafe { load(bytes2.0.as_ptr() as usize) };
         let bi = bi.unwrap();
-        let efi_mmap = bi.efi_memory_map();
+        let efi_mmap = bi.efi_memory_map_tag();
         assert!(efi_mmap.is_none());
     }
 

--- a/multiboot2/src/lib.rs
+++ b/multiboot2/src/lib.rs
@@ -50,7 +50,7 @@ pub use boot_loader_name::BootLoaderNameTag;
 #[cfg(feature = "builder")]
 use builder::traits::StructAsBytes;
 pub use command_line::CommandLineTag;
-pub use efi::{EFIImageHandle32, EFIImageHandle64, EFISdt32, EFISdt64};
+pub use efi::{EFIImageHandle32Tag, EFIImageHandle64Tag, EFISdt32, EFISdt64};
 pub use elf_sections::{
     ElfSection, ElfSectionFlags, ElfSectionIter, ElfSectionType, ElfSectionsTag,
 };
@@ -336,13 +336,13 @@ impl BootInformation {
     }
 
     /// Search for the EFI 32-bit image handle pointer tag.
-    pub fn efi_32_ih(&self) -> Option<&EFIImageHandle32> {
-        self.get_tag::<EFIImageHandle32, _>(TagType::Efi32Ih)
+    pub fn efi_32_ih_tag(&self) -> Option<&EFIImageHandle32Tag> {
+        self.get_tag::<EFIImageHandle32Tag, _>(TagType::Efi32Ih)
     }
 
     /// Search for the EFI 64-bit image handle pointer tag.
-    pub fn efi_64_ih(&self) -> Option<&EFIImageHandle64> {
-        self.get_tag::<EFIImageHandle64, _>(TagType::Efi64Ih)
+    pub fn efi_64_ih_tag(&self) -> Option<&EFIImageHandle64Tag> {
+        self.get_tag::<EFIImageHandle64Tag, _>(TagType::Efi64Ih)
     }
 
     /// Search for the Image Load Base Physical Address tag.
@@ -374,7 +374,7 @@ impl BootInformation {
     /// However, it doesn't forbid to use custom tags. Because of this, there
     /// exists the [`TagType`] abstraction. It is recommended to use this
     /// getter only for custom tags. For specified tags, use getters, such as
-    /// [`Self::efi_64_ih`].
+    /// [`Self::efi_64_ih_tag`].
     ///
     /// ## Use Custom Tags
     /// The following example shows how you may use this interface to parse
@@ -493,11 +493,11 @@ impl fmt::Debug for BootInformation {
         }
 
         debug
-            .field("efi_32_ih", &self.efi_32_ih())
-            .field("efi_64_ih", &self.efi_64_ih())
+            .field("efi_32_ih", &self.efi_32_ih_tag())
+            .field("efi_64_ih", &self.efi_64_ih_tag())
             .field("efi_sdt_32_tag", &self.efi_sdt_32_tag())
-            .field("efi_sdt_64_tag", &self.efi_sdt_64())
-            .field("efi_memory_map_tag", &self.efi_memory_map())
+            .field("efi_sdt_64_tag", &self.efi_sdt_64_tag())
+            .field("efi_memory_map_tag", &self.efi_memory_map_tag())
             .finish()
     }
 }

--- a/multiboot2/src/memory_map.rs
+++ b/multiboot2/src/memory_map.rs
@@ -206,8 +206,7 @@ const EFI_METADATA_SIZE: usize = mem::size_of::<TagTypeId>() + 3 * mem::size_of:
 
 /// EFI memory map as per EFI specification.
 #[derive(ptr_meta::Pointee)]
-// #[derive(Debug, PartialEq, Eq)] // wait for uefi-raw 0.3.0
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 pub struct EFIMemoryMapTag {
     typ: TagTypeId,

--- a/multiboot2/src/memory_map.rs
+++ b/multiboot2/src/memory_map.rs
@@ -205,8 +205,7 @@ impl StructAsBytes for BasicMemoryInfoTag {
 const EFI_METADATA_SIZE: usize = mem::size_of::<TagTypeId>() + 3 * mem::size_of::<u32>();
 
 /// EFI memory map as per EFI specification.
-#[derive(ptr_meta::Pointee)]
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ptr_meta::Pointee, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 pub struct EFIMemoryMapTag {
     typ: TagTypeId,


### PR DESCRIPTION
- memory-map: derive Eq + uefi-raw@0.3.0
- `ImageLoadPhysAddr` -> `ImageLoadPhysAddrTag`
- `EFIImageHandle32` -> `EFIImageHandle32Tag`
- `EFIImageHandle32` -> `EFIImageHandle64Tag`

Now, all tags do end with "Tag" -> consistency