### PR TITLE
various fixes

### DIFF
--- a/multiboot2/Changelog.md
+++ b/multiboot2/Changelog.md
@@ -17,6 +17,7 @@
 - **BREAKING** Renamed `EFISdt32` to `EFISdt32Tag`
 - **BREAKING** Renamed `EFISdt64` to `EFISdt64Tag`
 - **BREAKING** Renamed `EFIBootServicesNotExited` to `EFIBootServicesNotExitedTag`
+- **BREAKING** Renamed `CommandLineTag::command_line` renamed to `CommandLineTag::cmdline`
 - **\[Might be\] BREAKING** Added `TagTrait` trait which enables to use DSTs as multiboot2 tags. This is
   mostly relevant for the command line tag, the modules tag, and the bootloader
   name tag. However, this might also be relevant for users of custom multiboot2

--- a/multiboot2/src/boot_loader_name.rs
+++ b/multiboot2/src/boot_loader_name.rs
@@ -118,5 +118,6 @@ mod tests {
         let tag = BootLoaderNameTag::new(MSG);
         let bytes = tag.struct_as_bytes();
         assert_eq!(bytes, get_bytes());
+        assert_eq!(tag.name(), Ok(MSG));
     }
 }

--- a/multiboot2/src/builder/information.rs
+++ b/multiboot2/src/builder/information.rs
@@ -335,10 +335,7 @@ mod tests {
             mb2i.basic_memory_info_tag().unwrap().memory_upper(),
             7 * 1024
         );
-        assert_eq!(
-            mb2i.command_line_tag().unwrap().command_line().unwrap(),
-            "test"
-        );
+        assert_eq!(mb2i.command_line_tag().unwrap().cmdline().unwrap(), "test");
         let mut modules = mb2i.module_tags();
         let module_1 = modules.next().unwrap();
         assert_eq!(module_1.start_address(), 0);

--- a/multiboot2/src/command_line.rs
+++ b/multiboot2/src/command_line.rs
@@ -127,5 +127,6 @@ mod tests {
         let tag = CommandLineTag::new(MSG);
         let bytes = tag.struct_as_bytes();
         assert_eq!(bytes, get_bytes());
+        assert_eq!(tag.cmdline(), Ok(MSG));
     }
 }

--- a/multiboot2/src/command_line.rs
+++ b/multiboot2/src/command_line.rs
@@ -52,11 +52,11 @@ impl CommandLineTag {
     /// ```rust,no_run
     /// # let boot_info = unsafe { multiboot2::load(0xdeadbeef).unwrap() };
     /// if let Some(tag) = boot_info.command_line_tag() {
-    ///     let command_line = tag.command_line();
+    ///     let command_line = tag.cmdline();
     ///     assert_eq!(Ok("/bootarg"), command_line);
     /// }
     /// ```
-    pub fn command_line(&self) -> Result<&str, str::Utf8Error> {
+    pub fn cmdline(&self) -> Result<&str, str::Utf8Error> {
         Tag::get_dst_str_slice(&self.cmdline)
     }
 }
@@ -66,7 +66,7 @@ impl Debug for CommandLineTag {
         f.debug_struct("CommandLineTag")
             .field("typ", &{ self.typ })
             .field("size", &{ self.size })
-            .field("cmdline", &self.command_line())
+            .field("cmdline", &self.cmdline())
             .finish()
     }
 }
@@ -115,7 +115,7 @@ mod tests {
         let tag = unsafe { &*tag.as_ptr().cast::<Tag>() };
         let tag = tag.cast_tag::<CommandLineTag>();
         assert_eq!({ tag.typ }, TagType::Cmdline);
-        assert_eq!(tag.command_line().expect("must be valid UTF-8"), MSG);
+        assert_eq!(tag.cmdline().expect("must be valid UTF-8"), MSG);
     }
 
     /// Test to generate a tag from a given string.

--- a/multiboot2/src/lib.rs
+++ b/multiboot2/src/lib.rs
@@ -285,7 +285,8 @@ impl<'a> BootInformation<'a> {
         self.get_tag::<BasicMemoryInfoTag, _>(TagType::BasicMeminfo)
     }
 
-    /// Search for the ELF Sections.
+    /// Returns an [`ElfSectionIter`] iterator over the ELF Sections, if the
+    /// [`ElfSectionsTag`] is present.
     ///
     /// # Examples
     ///

--- a/multiboot2/src/lib.rs
+++ b/multiboot2/src/lib.rs
@@ -497,7 +497,7 @@ impl fmt::Debug for BootInformation<'_> {
                 "command_line",
                 &self
                     .command_line_tag()
-                    .and_then(|x| x.command_line().ok())
+                    .and_then(|x| x.cmdline().ok())
                     .unwrap_or(""),
             )
             .field("memory_areas", &self.memory_map_tag())
@@ -1392,7 +1392,7 @@ mod tests {
             "",
             bi.command_line_tag()
                 .expect("tag must present")
-                .command_line()
+                .cmdline()
                 .expect("must be valid utf-8")
         );
 

--- a/multiboot2/src/module.rs
+++ b/multiboot2/src/module.rs
@@ -173,5 +173,6 @@ mod tests {
         let tag = ModuleTag::new(0, 0, MSG);
         let bytes = tag.struct_as_bytes();
         assert_eq!(bytes, get_bytes());
+        assert_eq!(tag.cmdline(), Ok(MSG));
     }
 }


### PR DESCRIPTION
Regarding 9cf763014624003044a2a406e0c497fb613a27e4:

I don't exactly understand why, but running this in the integration test
revealed a different behaviour compared to the unit test. In the unit test
environment, it always seemed like the next multiple of 8 is used for each
allocation as size. In the integration test, I did not encounter this. I
don't know what's the best solution here. Probably, just don't be too 
strict.