### PR TITLE
multiboot2: create DSTs: hopefully better memory fix

### DIFF
--- a/multiboot2/src/builder/mod.rs
+++ b/multiboot2/src/builder/mod.rs
@@ -6,59 +6,104 @@ pub(crate) mod traits;
 pub use information::InformationBuilder;
 
 use alloc::alloc::alloc;
-use alloc::boxed::Box;
 use core::alloc::Layout;
-use core::mem::{align_of_val, size_of};
+use core::marker::PhantomData;
+use core::mem::size_of;
 use core::ops::Deref;
+use core::ptr::NonNull;
 
 use crate::{Tag, TagTrait, TagTypeId};
 
-/// Create a boxed tag with the given content.
+/// A helper type to create boxed DST, i.e., tags with a dynamic size for the
+/// builder. This is tricky in Rust. This type behaves similar to the regular
+/// `Box` type except that it ensure the same layout is used for the (explicit)
+/// allocation and the (implicit) deallocation of memory. Otherwise, I didn't
+/// found any way to figure out the right layout for a DST. Miri always reported
+/// issues that the deallocation used a wrong layout.
 ///
-/// # Parameters
-/// - `typ` - The given [`TagTypeId`]
-/// - `content` - All payload bytes of the DST tag without the tag type or the
-///               size. The memory is only read and can be discarded afterwards.
-pub(super) fn boxed_dst_tag<T: TagTrait<Metadata = usize> + ?Sized>(
-    typ: impl Into<TagTypeId>,
-    content: &[u8],
-) -> Box<T> {
-    // Currently, I do not find a nice way of making this dynamic so that also
-    // miri is happy. But it seems that 4 is fine.
-    const ALIGN: usize = 4;
+/// Technically, I'm certain this code is memory safe. But with this type, I
+/// also can convince miri that it is.
+#[derive(Debug, Eq)]
+pub struct BoxedDst<T: ?Sized> {
+    ptr: core::ptr::NonNull<T>,
+    layout: Layout,
+    // marker: I used this only as the regular Box impl also does it.
+    _marker: PhantomData<T>,
+}
 
-    let tag_size = size_of::<TagTypeId>() + size_of::<u32>() + content.len();
-    let layout = Layout::from_size_align(tag_size, ALIGN).unwrap();
-    let ptr = unsafe { alloc(layout) };
-    assert!(!ptr.is_null());
+impl<T: TagTrait<Metadata = usize> + ?Sized> BoxedDst<T> {
+    /// Create a boxed tag with the given content.
+    ///
+    /// # Parameters
+    /// - `typ` - The given [`TagTypeId`]
+    /// - `content` - All payload bytes of the DST tag without the tag type or
+    ///               the size. The memory is only read and can be discarded
+    ///               afterwards.
+    pub(crate) fn new(typ: impl Into<TagTypeId>, content: &[u8]) -> Self {
+        // Currently, I do not find a nice way of making this dynamic so that
+        // also miri is guaranteed to be happy. But it seems that 4 is fine
+        // here. I do have control over allocation and deallocation.
+        const ALIGN: usize = 4;
 
-    // write tag content to memory
-    unsafe {
-        // write tag type
-        let ptrx = ptr.cast::<TagTypeId>();
-        ptrx.write(typ.into());
+        let tag_size = size_of::<TagTypeId>() + size_of::<u32>() + content.len();
 
-        // write tag size
-        let ptrx = ptrx.add(1).cast::<u32>();
-        ptrx.write(tag_size as u32);
+        // By using miri, I could figure out that there often are problems where
+        // miri thinks an allocation is smaller then necessary. Most probably
+        // due to not packed structs. Using packed structs however
+        // (especially with DSTs), is a crazy ass pain and unusable :/ Therefore,
+        // the best solution I can think of is to allocate a few byte more than
+        // necessary. I think that during runtime, everything works fine and
+        // that no memory issues are present.
+        let alloc_size = (tag_size + 7) & !7; // align to next 8 byte boundary
+        let layout = Layout::from_size_align(alloc_size, ALIGN).unwrap();
+        let ptr = unsafe { alloc(layout) };
+        assert!(!ptr.is_null());
 
-        // write rest of content
-        let ptrx = ptrx.add(1).cast::<u8>();
-        let tag_content_slice = core::slice::from_raw_parts_mut(ptrx, content.len());
-        for (i, &byte) in content.iter().enumerate() {
-            tag_content_slice[i] = byte;
+        // write tag content to memory
+        unsafe {
+            // write tag type
+            let ptrx = ptr.cast::<TagTypeId>();
+            ptrx.write(typ.into());
+
+            // write tag size
+            let ptrx = ptrx.add(1).cast::<u32>();
+            ptrx.write(tag_size as u32);
+
+            // write rest of content
+            let ptrx = ptrx.add(1).cast::<u8>();
+            let tag_content_slice = core::slice::from_raw_parts_mut(ptrx, content.len());
+            for (i, &byte) in content.iter().enumerate() {
+                tag_content_slice[i] = byte;
+            }
+        }
+
+        let base_tag = unsafe { &*ptr.cast::<Tag>() };
+        let raw: *mut T = ptr_meta::from_raw_parts_mut(ptr.cast(), T::dst_size(base_tag));
+
+        Self {
+            ptr: NonNull::new(raw).unwrap(),
+            layout,
+            _marker: PhantomData,
         }
     }
+}
 
-    let base_tag = unsafe { &*ptr.cast::<Tag>() };
-    let raw: *mut T = ptr_meta::from_raw_parts_mut(ptr.cast(), T::dst_size(base_tag));
+impl<T: ?Sized> Drop for BoxedDst<T> {
+    fn drop(&mut self) {
+        unsafe { alloc::alloc::dealloc(self.ptr.as_ptr().cast(), self.layout) }
+    }
+}
 
-    unsafe {
-        let boxed = Box::from_raw(raw);
-        let reference: &T = boxed.deref();
-        // If this panics, please create an issue on GitHub.
-        assert_eq!(align_of_val(reference), ALIGN);
-        boxed
+impl<T: ?Sized> Deref for BoxedDst<T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        unsafe { self.ptr.as_ref() }
+    }
+}
+
+impl<T: ?Sized + PartialEq> PartialEq for BoxedDst<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.deref().eq(other.deref())
     }
 }
 
@@ -94,7 +139,7 @@ mod tests {
         let tag_type_id = 1337_u32;
         let content = "hallo";
 
-        let tag = boxed_dst_tag::<CustomTag>(tag_type_id, content.as_bytes());
+        let tag = unsafe { BoxedDst::<CustomTag>::new(tag_type_id, content.as_bytes()) };
         assert_eq!(tag.typ, tag_type_id);
         assert_eq!(tag.size as usize, METADATA_SIZE + content.len());
         assert_eq!(tag.string(), Ok(content));

--- a/multiboot2/src/elf_sections.rs
+++ b/multiboot2/src/elf_sections.rs
@@ -5,10 +5,7 @@ use core::mem::size_of;
 use core::str::Utf8Error;
 
 #[cfg(feature = "builder")]
-use {
-    crate::builder::boxed_dst_tag, crate::builder::traits::StructAsBytes, crate::TagType,
-    alloc::boxed::Box,
-};
+use {crate::builder::traits::StructAsBytes, crate::builder::BoxedDst, crate::TagType};
 
 const METADATA_SIZE: usize = size_of::<TagTypeId>() + 4 * size_of::<u32>();
 
@@ -29,7 +26,12 @@ pub struct ElfSectionsTag {
 impl ElfSectionsTag {
     /// Create a new ElfSectionsTag with the given data.
     #[cfg(feature = "builder")]
-    pub fn new(number_of_sections: u32, entry_size: u32, shndx: u32, sections: &[u8]) -> Box<Self> {
+    pub fn new(
+        number_of_sections: u32,
+        entry_size: u32,
+        shndx: u32,
+        sections: &[u8],
+    ) -> BoxedDst<Self> {
         let mut bytes = [
             number_of_sections.to_le_bytes(),
             entry_size.to_le_bytes(),
@@ -37,7 +39,7 @@ impl ElfSectionsTag {
         ]
         .concat();
         bytes.extend_from_slice(sections);
-        boxed_dst_tag(TagType::ElfSections, &bytes)
+        BoxedDst::new(TagType::ElfSections, &bytes)
     }
 
     /// Get an iterator of loaded ELF sections.

--- a/multiboot2/src/framebuffer.rs
+++ b/multiboot2/src/framebuffer.rs
@@ -7,8 +7,8 @@ use derive_more::Display;
 
 #[cfg(feature = "builder")]
 use {
-    crate::builder::boxed_dst_tag, crate::builder::traits::StructAsBytes, crate::TagType,
-    alloc::boxed::Box, alloc::vec::Vec,
+    crate::builder::traits::StructAsBytes, crate::builder::BoxedDst, crate::TagType,
+    alloc::vec::Vec,
 };
 
 /// Helper struct to read bytes from a raw pointer and increase the pointer
@@ -95,14 +95,14 @@ impl FramebufferTag {
         height: u32,
         bpp: u8,
         buffer_type: FramebufferType,
-    ) -> Box<Self> {
+    ) -> BoxedDst<Self> {
         let mut bytes: Vec<u8> = address.to_le_bytes().into();
         bytes.extend(pitch.to_le_bytes());
         bytes.extend(width.to_le_bytes());
         bytes.extend(height.to_le_bytes());
         bytes.extend(bpp.to_le_bytes());
         bytes.extend(buffer_type.to_bytes());
-        boxed_dst_tag(TagType::Framebuffer, &bytes)
+        BoxedDst::new(TagType::Framebuffer, &bytes)
     }
 
     /// Contains framebuffer physical address.

--- a/multiboot2/src/memory_map.rs
+++ b/multiboot2/src/memory_map.rs
@@ -8,7 +8,7 @@ pub use uefi_raw::table::boot::MemoryDescriptor as EFIMemoryDesc;
 pub use uefi_raw::table::boot::MemoryType as EFIMemoryAreaType;
 
 #[cfg(feature = "builder")]
-use {crate::builder::boxed_dst_tag, crate::builder::traits::StructAsBytes, alloc::boxed::Box};
+use {crate::builder::traits::StructAsBytes, crate::builder::BoxedDst};
 
 const METADATA_SIZE: usize = mem::size_of::<TagTypeId>() + 3 * mem::size_of::<u32>();
 
@@ -34,14 +34,14 @@ pub struct MemoryMapTag {
 
 impl MemoryMapTag {
     #[cfg(feature = "builder")]
-    pub fn new(areas: &[MemoryArea]) -> Box<Self> {
+    pub fn new(areas: &[MemoryArea]) -> BoxedDst<Self> {
         let entry_size: u32 = mem::size_of::<MemoryArea>().try_into().unwrap();
         let entry_version: u32 = 0;
         let mut bytes = [entry_size.to_le_bytes(), entry_version.to_le_bytes()].concat();
         for area in areas {
             bytes.extend(area.struct_as_bytes());
         }
-        boxed_dst_tag(TagType::Mmap, bytes.as_slice())
+        BoxedDst::new(TagType::Mmap, bytes.as_slice())
     }
 
     /// Returns the entry size.
@@ -218,7 +218,7 @@ impl EFIMemoryMapTag {
     /// Create a new EFI memory map tag with the given memory descriptors.
     /// Version and size can't be set because you're passing a slice of
     /// EFIMemoryDescs, not the ones you might have gotten from the firmware.
-    pub fn new(descs: &[EFIMemoryDesc]) -> Box<Self> {
+    pub fn new(descs: &[EFIMemoryDesc]) -> BoxedDst<Self> {
         // update this when updating EFIMemoryDesc
         const MEMORY_DESCRIPTOR_VERSION: u32 = 1;
         let mut bytes = [
@@ -229,7 +229,7 @@ impl EFIMemoryMapTag {
         for desc in descs {
             bytes.extend(desc.struct_as_bytes());
         }
-        boxed_dst_tag(TagType::EfiMmap, bytes.as_slice())
+        BoxedDst::new(TagType::EfiMmap, bytes.as_slice())
     }
 
     /// Return an iterator over ALL marked memory areas.

--- a/multiboot2/src/smbios.rs
+++ b/multiboot2/src/smbios.rs
@@ -2,8 +2,8 @@ use crate::{Tag, TagTrait, TagTypeId};
 use core::fmt::Debug;
 #[cfg(feature = "builder")]
 use {
-    crate::builder::boxed_dst_tag, crate::builder::traits::StructAsBytes, crate::TagType,
-    alloc::boxed::Box, core::convert::TryInto,
+    crate::builder::traits::StructAsBytes, crate::builder::BoxedDst, crate::TagType,
+    core::convert::TryInto,
 };
 
 const METADATA_SIZE: usize = core::mem::size_of::<TagTypeId>()
@@ -24,10 +24,10 @@ pub struct SmbiosTag {
 
 impl SmbiosTag {
     #[cfg(feature = "builder")]
-    pub fn new(major: u8, minor: u8, tables: &[u8]) -> Box<Self> {
+    pub fn new(major: u8, minor: u8, tables: &[u8]) -> BoxedDst<Self> {
         let mut bytes = [major, minor, 0, 0, 0, 0, 0, 0].to_vec();
         bytes.extend(tables);
-        boxed_dst_tag(TagType::Smbios, &bytes)
+        BoxedDst::new(TagType::Smbios, &bytes)
     }
 }
 


### PR DESCRIPTION
There where more memory issues (according to miri) in the boxed_dst_tag function. I tried many things but I came to the conclusion:
- creating DSTs that are packed and satisfying miri is a pain

Making every struct packed would help to satisfy miri with allocations/deallocations but using packed structs in Rust is a pain for itself. Using packed DSTs is a total meltdown...

So I think, using my own Boxed-like wrapper is the best solution we can have so far. I'm 99% certain that there are no memory issues at runtime and that only miri complains under certain cirumstances.