### PR TITLE
memory_map: support non-standard types

### DIFF
--- a/integration-test/bins/multiboot2_chainloader/src/loader.rs
+++ b/integration-test/bins/multiboot2_chainloader/src/loader.rs
@@ -1,6 +1,7 @@
 use elf_rs::{ElfFile, ProgramHeaderEntry, ProgramType};
 use multiboot2::{
-    BootLoaderNameTag, CommandLineTag, MemoryArea, MemoryAreaType, MemoryMapTag, ModuleTag,
+    BootLoaderNameTag, CommandLineTag, MemoryArea, MemoryAreaType, MemoryMapTag,
+    ModuleTag,
 };
 
 /// Loads the first module into memory. Assumes that the module is a ELF file.
@@ -25,7 +26,6 @@ pub fn load_module(mut modules: multiboot::information::ModuleIter) -> ! {
             unsafe { multiboot2_header::Multiboot2Header::load(hdr.0.as_ptr().cast()) }.unwrap();
         log::info!("Multiboot2 header:\n{hdr:#?}");
     }
-
 
     // Map the load segments into memory (at their corresponding link).
     {

--- a/integration-test/bins/rust-toolchain.toml
+++ b/integration-test/bins/rust-toolchain.toml
@@ -1,6 +1,7 @@
 [toolchain]
 channel = "nightly-2023-06-22"
-profile = "minimal"
+profile = "default"
 components = [
-    "rust-src"
+    "rust-src",
+    "rustfmt",
 ]

--- a/multiboot2-header/src/builder/mod.rs
+++ b/multiboot2-header/src/builder/mod.rs
@@ -2,7 +2,7 @@
 
 mod header;
 mod information_request;
-pub(self) mod traits;
+pub(crate) mod traits;
 
 pub use header::HeaderBuilder;
 pub use information_request::InformationRequestHeaderTagBuilder;

--- a/multiboot2/Changelog.md
+++ b/multiboot2/Changelog.md
@@ -1,6 +1,8 @@
 # CHANGELOG for crate `multiboot2`
 ## Unreleased
-- **Breaking** Make functions of `InformationBuilder` chainable. They now consume the builder.
+- **BREAKING** Make functions of `InformationBuilder` chainable. They now consume the builder.
+- **BREAKING** Allow non-standard memory area types by using new pair of
+  corresponding types: `MemoryAreaTypeId` and `MemoryAreaType`.
 
 ## 0.16.0 (2023-06-23)
 - **BREAKING** renamed `MULTIBOOT2_BOOTLOADER_MAGIC` to `MAGIC`

--- a/multiboot2/src/lib.rs
+++ b/multiboot2/src/lib.rs
@@ -62,7 +62,7 @@ pub use framebuffer::{FramebufferColor, FramebufferField, FramebufferTag, Frameb
 pub use image_load_addr::ImageLoadPhysAddrTag;
 pub use memory_map::{
     BasicMemoryInfoTag, EFIBootServicesNotExitedTag, EFIMemoryAreaType, EFIMemoryDesc,
-    EFIMemoryMapTag, MemoryArea, MemoryAreaType, MemoryMapTag,
+    EFIMemoryMapTag, MemoryArea, MemoryAreaType, MemoryAreaTypeId, MemoryMapTag,
 };
 pub use module::{ModuleIter, ModuleTag};
 pub use rsdp::{RsdpV1Tag, RsdpV2Tag};
@@ -583,6 +583,7 @@ impl<T: Pointee<Metadata = ()>> TagTrait for T {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::memory_map::MemoryAreaType;
     use core::str::Utf8Error;
 
     #[test]

--- a/multiboot2/src/tag_type.rs
+++ b/multiboot2/src/tag_type.rs
@@ -19,13 +19,20 @@ use core::str::Utf8Error;
 /// Multiboot2 [`Tag`]. This type can easily be created from or converted to
 /// [`TagType`].
 #[repr(transparent)]
-#[derive(Copy, Clone, Debug, PartialOrd, PartialEq, Eq, Ord, Hash)]
+#[derive(Copy, Clone, PartialOrd, PartialEq, Eq, Ord, Hash)]
 pub struct TagTypeId(u32);
 
 impl TagTypeId {
     /// Constructor.
     pub fn new(val: u32) -> Self {
         Self(val)
+    }
+}
+
+impl Debug for TagTypeId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        let tag_type = TagType::from(*self);
+        Debug::fmt(&tag_type, f)
     }
 }
 


### PR DESCRIPTION
Support non-standard types in the memory map. We use this for example in our virtualization stack based on [Hedron](https://github.com/cyberus-technology/hedron).

Thanks to @scholzp for finding this issue.