### PR TITLE
multiboot2: foundation for mutable reference to tags

### DIFF
--- a/multiboot2/src/boot_loader_name.rs
+++ b/multiboot2/src/boot_loader_name.rs
@@ -39,7 +39,7 @@ impl BootLoaderNameTag {
     ///
     /// ```rust,no_run
     /// # use multiboot2::{BootInformation, BootInformationHeader};
-    /// # let ptr = 0xdeadbeef as *const BootInformationHeader;
+    /// # let ptr = 0xdeadbeef as *mut BootInformationHeader;
     /// # let boot_info = unsafe { BootInformation::load(ptr).unwrap() };
     /// if let Some(tag) = boot_info.boot_loader_name_tag() {
     ///     assert_eq!(Ok("GRUB 2.02~beta3-5"), tag.name());

--- a/multiboot2/src/builder/information.rs
+++ b/multiboot2/src/builder/information.rs
@@ -448,7 +448,7 @@ mod tests {
         let mb2i_data = create_builder().build();
 
         // Step 2/2: Test the built MBI
-        let mb2i = unsafe { BootInformation::load(mb2i_data.as_ptr().cast()) }
+        let mb2i = unsafe { BootInformation::load(mb2i_data.as_ptr().cast_mut().cast()) }
             .expect("generated information should be readable");
 
         assert_eq!(mb2i.basic_memory_info_tag().unwrap().memory_lower(), 640);

--- a/multiboot2/src/command_line.rs
+++ b/multiboot2/src/command_line.rs
@@ -48,7 +48,7 @@ impl CommandLineTag {
     ///
     /// ```rust,no_run
     /// # use multiboot2::{BootInformation, BootInformationHeader};
-    /// # let ptr = 0xdeadbeef as *const BootInformationHeader;
+    /// # let ptr = 0xdeadbeef as *mut BootInformationHeader;
     /// # let boot_info = unsafe { BootInformation::load(ptr).unwrap() };
     /// if let Some(tag) = boot_info.command_line_tag() {
     ///     let command_line = tag.cmdline();


### PR DESCRIPTION
This is the foundation for a mutable boot information and another approach than #140. By using the `NonNull` facility, we can ensure that the compiler will not optimize away any mutable operations. I could not find a way to use `UnsafeCell` here in a meaningful way. 

I think this approach has the advantage that the public API is barely changed - unlike in #140. 