### PR TITLE
updating header to not include multiboot with alloc

### DIFF
--- a/multiboot2-header/Cargo.toml
+++ b/multiboot2-header/Cargo.toml
@@ -47,7 +47,7 @@ derive_more.workspace = true
 # log.workspace = true
 
 # used for MBI tags
-multiboot2 = "0.19.0"
+multiboot2 = { version = "0.19.0", default-features = false }
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
Currently, when using multiboot2-header with no alloc (default-features = false), you wil get `error: no global memory allocator found but one is required` error.  Reason being , when including multiboot2 for MBI tags, it will also include alloc and builder. This patch fixes that so that you can use multiboot2-header as intended without alloc when it is off.