### PR TITLE
multiboot2: builder: Allow to specify SMBIOS tag multiple times

### DIFF
--- a/multiboot2/src/builder/information.rs
+++ b/multiboot2/src/builder/information.rs
@@ -288,7 +288,10 @@ impl InformationBuilder {
     }
 
     fn tag_is_allowed_multiple_times(tag_type: TagType) -> bool {
-        matches!(tag_type, TagType::Module | TagType::Custom(_))
+        matches!(
+            tag_type,
+            TagType::Module | TagType::Smbios | TagType::Custom(_)
+        )
     }
 }
 


### PR DESCRIPTION
Some devices have multiple major versions of SMBIOS, say 2 and 3, and I want to pass them all and let the OS decide which one to use.

The standard doesn't explicitly state something along the lines of "this tag may occur multiple times", but it also doesn't specify that tags may occur just once, so I'm not sure, if this makes sense.

This used to work before https://github.com/rust-osdev/multiboot2/commit/3956403ee64e7e348e94df7ec44962ef97c9c9cd.