### PR TITLE
multiboot2: fix handling of efi memory map

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,7 +27,7 @@ checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "multiboot2"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "bitflags",
  "derive_more",

--- a/integration-test/bins/Cargo.lock
+++ b/integration-test/bins/Cargo.lock
@@ -4,15 +4,15 @@ version = 3
 
 [[package]]
 name = "anyhow"
-version = "1.0.82"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f538837af36e6f6a9be0faa67f9a314f8119e4e4b5867c6ab40ed60360142519"
+checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
 name = "autocfg"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "bit_field"
@@ -45,9 +45,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
+checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
 
 [[package]]
 name = "elf_rs"
@@ -97,6 +97,8 @@ dependencies = [
 [[package]]
 name = "multiboot2"
 version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d67e1b461b49127f2226c78a2b4090f72212c44fa27342bcfef93dd39bd6b86"
 dependencies = [
  "bitflags 2.5.0",
  "derive_more",
@@ -107,9 +109,7 @@ dependencies = [
 
 [[package]]
 name = "multiboot2"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d67e1b461b49127f2226c78a2b4090f72212c44fa27342bcfef93dd39bd6b86"
+version = "0.20.1"
 dependencies = [
  "bitflags 2.5.0",
  "derive_more",
@@ -123,7 +123,7 @@ name = "multiboot2-header"
 version = "0.4.0"
 dependencies = [
  "derive_more",
- "multiboot2 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "multiboot2 0.20.0",
 ]
 
 [[package]]
@@ -135,7 +135,7 @@ dependencies = [
  "good_memory_allocator",
  "log",
  "multiboot",
- "multiboot2 0.20.0",
+ "multiboot2 0.20.1",
  "multiboot2-header",
  "util",
 ]
@@ -147,31 +147,31 @@ dependencies = [
  "anyhow",
  "good_memory_allocator",
  "log",
- "multiboot2 0.20.0",
+ "multiboot2 0.20.1",
  "util",
  "x86",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "paste"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.81"
+version = "1.0.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
+checksum = "ec96c6a92621310b51366f1e28d05ef11489516e93be030060e5fc12024a49d6"
 dependencies = [
  "unicode-ident",
 ]

--- a/multiboot2/Cargo.toml
+++ b/multiboot2/Cargo.toml
@@ -6,7 +6,7 @@ Multiboot2-compliant bootloaders, such as GRUB. It supports all tags from the
 specification including full support for the sections of ELF files. This library
 is `no_std` and can be used in a Multiboot2-kernel.
 """
-version = "0.20.0"
+version = "0.20.1"
 authors = [
     "Philipp Oppermann <dev@phil-opp.com>",
     "Calvin Lee <cyrus296@gmail.com>",

--- a/multiboot2/Changelog.md
+++ b/multiboot2/Changelog.md
@@ -1,6 +1,6 @@
 # CHANGELOG for crate `multiboot2`
 
-## 0.20.1
+## 0.20.1 (2024-05-26)
 
 - fixed the handling of `EFIMemoryMapTag` and `EFIMemoryAreaIter`
 - **BREAKING** Fixed wrong creation of `EFIMemoryMapTag`.

--- a/multiboot2/Changelog.md
+++ b/multiboot2/Changelog.md
@@ -6,6 +6,7 @@
 - **BREAKING** Fixed wrong creation of `EFIMemoryMapTag`.
   `EFIMemoryMapTag::new` was replaced by `EFIMemoryMapTag::new_from_descs` and
   `EFIMemoryMapTag::new_from_map`.
+- `ModuleTag::new`'s `end` parameter now must be bigger than `start`.
 
 ## 0.20.0 (2024-05-01)
 

--- a/multiboot2/Changelog.md
+++ b/multiboot2/Changelog.md
@@ -3,6 +3,9 @@
 ## 0.20.1
 
 - fixed the handling of `EFIMemoryMapTag` and `EFIMemoryAreaIter`
+- **BREAKING** Fixed wrong creation of `EFIMemoryMapTag`.
+  `EFIMemoryMapTag::new` was replaced by `EFIMemoryMapTag::new_from_descs` and
+  `EFIMemoryMapTag::new_from_map`.
 
 ## 0.20.0 (2024-05-01)
 

--- a/multiboot2/Changelog.md
+++ b/multiboot2/Changelog.md
@@ -1,6 +1,8 @@
 # CHANGELOG for crate `multiboot2`
 
-## Unreleased
+## 0.20.1
+
+- fixed the handling of `EFIMemoryMapTag` and `EFIMemoryAreaIter`
 
 ## 0.20.0 (2024-05-01)
 

--- a/multiboot2/src/lib.rs
+++ b/multiboot2/src/lib.rs
@@ -77,8 +77,8 @@ pub use end::EndTag;
 pub use framebuffer::{FramebufferColor, FramebufferField, FramebufferTag, FramebufferType};
 pub use image_load_addr::ImageLoadPhysAddrTag;
 pub use memory_map::{
-    BasicMemoryInfoTag, EFIMemoryAreaType, EFIMemoryDesc, EFIMemoryMapTag, MemoryArea,
-    MemoryAreaType, MemoryAreaTypeId, MemoryMapTag,
+    BasicMemoryInfoTag, EFIMemoryAreaType, EFIMemoryAttribute, EFIMemoryDesc, EFIMemoryMapTag,
+    MemoryArea, MemoryAreaType, MemoryAreaTypeId, MemoryMapTag,
 };
 pub use module::{ModuleIter, ModuleTag};
 pub use ptr_meta::Pointee;

--- a/multiboot2/src/memory_map.rs
+++ b/multiboot2/src/memory_map.rs
@@ -428,6 +428,8 @@ mod tests {
     use super::*;
 
     #[test]
+    #[cfg(feature = "builder")]
+    #[cfg_attr(miri, ignore)]
     fn construction_and_parsing() {
         let descs = [
             EFIMemoryDesc {

--- a/multiboot2/src/memory_map.rs
+++ b/multiboot2/src/memory_map.rs
@@ -1,6 +1,7 @@
 //! Module for [`MemoryMapTag`], [`EFIMemoryMapTag`] and [`BasicMemoryInfoTag`]
 //! and corresponding helper types.
 
+pub use uefi_raw::table::boot::MemoryAttribute as EFIMemoryAttribute;
 pub use uefi_raw::table::boot::MemoryDescriptor as EFIMemoryDesc;
 pub use uefi_raw::table::boot::MemoryType as EFIMemoryAreaType;
 

--- a/multiboot2/src/module.rs
+++ b/multiboot2/src/module.rs
@@ -26,6 +26,8 @@ pub struct ModuleTag {
 impl ModuleTag {
     #[cfg(feature = "builder")]
     pub fn new(start: u32, end: u32, cmdline: &str) -> BoxedDst<Self> {
+        assert!(end > start, "must have a size");
+
         let mut cmdline_bytes: Vec<_> = cmdline.bytes().collect();
         if !cmdline_bytes.ends_with(&[0]) {
             // terminating null-byte
@@ -135,7 +137,7 @@ mod tests {
             &((TagType::Module.val()).to_le_bytes()),
             &size.to_le_bytes(),
             &0_u32.to_le_bytes(),
-            &0_u32.to_le_bytes(),
+            &1_u32.to_le_bytes(),
             MSG.as_bytes(),
             // Null Byte
             &[0],
@@ -161,15 +163,15 @@ mod tests {
     #[test]
     #[cfg(feature = "builder")]
     fn test_build_str() {
-        let tag = ModuleTag::new(0, 0, MSG);
+        let tag = ModuleTag::new(0, 1, MSG);
         let bytes = tag.as_bytes();
         assert_eq!(bytes, get_bytes());
         assert_eq!(tag.cmdline(), Ok(MSG));
 
         // test also some bigger message
-        let tag = ModuleTag::new(0, 0, "AbCdEfGhUjK YEAH");
+        let tag = ModuleTag::new(0, 1, "AbCdEfGhUjK YEAH");
         assert_eq!(tag.cmdline(), Ok("AbCdEfGhUjK YEAH"));
-        let tag = ModuleTag::new(0, 0, "AbCdEfGhUjK YEAH".repeat(42).as_str());
+        let tag = ModuleTag::new(0, 1, "AbCdEfGhUjK YEAH".repeat(42).as_str());
         assert_eq!(tag.cmdline(), Ok("AbCdEfGhUjK YEAH".repeat(42).as_str()));
     }
 }

--- a/multiboot2/src/tag_trait.rs
+++ b/multiboot2/src/tag_trait.rs
@@ -51,7 +51,7 @@ pub trait TagTrait: Pointee {
     /// Callers must be sure that the "size" field of the provided [`Tag`] is
     /// sane and the underlying memory valid. The implementation of this trait
     /// **must have** a correct [`Self::dst_size`] implementation.
-    unsafe fn from_base_tag<'a>(tag: &Tag) -> &'a Self {
+    unsafe fn from_base_tag(tag: &Tag) -> &Self {
         let ptr = core::ptr::addr_of!(*tag);
         let ptr = ptr_meta::from_raw_parts(ptr.cast(), Self::dst_size(tag));
         &*ptr


### PR DESCRIPTION
This closes #215 